### PR TITLE
Test/local import completeness check

### DIFF
--- a/docs/plans/2026-07-08-001-test-local-import-audit-plan.md
+++ b/docs/plans/2026-07-08-001-test-local-import-audit-plan.md
@@ -1,0 +1,236 @@
+---
+title: Local Import Completeness Check - Plan
+type: test
+date: 2026-07-08
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Local Import Completeness Check - Plan
+
+## Goal Capsule
+
+- **Objective:** Ship an automated, CI-enforced check that would have caught the exact "works on my machine, breaks on a fresh clone" bug fixed in commit `0150a27` — a local import whose target file is missing or untracked, or whose imported symbol is undefined — with no new dependencies, no CI workflow changes, and no shim-maintenance burden.
+- **Authority hierarchy:** This plan governs implementation choices. The facts cited under Sources & Research are authoritative over assumptions about current repo state; re-verify them if the repo has moved on.
+- **Stop conditions:** Pause and record as an Open Question if implementation discovers dynamic import patterns (`importlib.import_module`, string-based imports, `__import__()`) — those are invisible to AST parsing and the static approach in this plan cannot see them. A `try/except ImportError` around a normal `import X` / `from X import Y` statement is NOT a stop condition: the import statement is still a regular AST node regardless of the surrounding control flow, so the checker sees and verifies it like any other local import (confirmed present today in `action_recognition.py`, `pipeline.py`, and `llm/llm_chat_widget.py` — see Sources & Research).
+- **Execution profile:** `code`, Standard depth, single session, 4 implementation units, no phasing.
+- **Tail ownership:** Implementer runs `pytest -q` locally before calling the plan done. No deploy or release step is involved — this is a test-only addition.
+
+---
+
+## Product Contract
+
+### Summary
+
+Add a static, AST-based checker that verifies every local (repo-internal) Python import resolves to a git-tracked file and, where a specific symbol is imported, that the symbol is actually defined in the target. Wire it into the existing test suite so it runs automatically via the current `pytest -q` CI step — no new CI workflow, dependency, or heavy-dependency shim required.
+
+### Problem Frame
+
+Commit `0150a27` fixed a fresh-clone breakage: three files existed on the original developer's machine but were never `git add`ed, so `import modules.video_regions`, `import video_ai_editor.vr_video_view`, and `from version import __edition__` all failed after a clean clone. The bug survived at least 2 days and 5 intervening commits of green CI (`691e97f`, `1234b2e`, `49d7991`, `9c09b5e`, `980b759`) because no test exercised those import paths — and the one test that does import `pipeline.py` deliberately mocks out `modules.motion_scene_detect_optimized`, the exact module whose real import pulled in the missing `modules.video_regions` (`tests/test_pipeline_legacy_imports.py:34-44`). An audit run during planning confirmed the current tree is clean (no other untracked-but-imported files, no other undefined symbols in a spot-checked sample) — this plan is a pure safeguard, not a cleanup.
+
+A narrower fix — un-mocking `modules.motion_scene_detect_optimized` in the one existing test — was considered and rejected: it would only have caught the `modules.video_regions` sub-bug, not the unrelated `version.py` `__edition__` sub-bug in the same commit, and it does nothing to prevent the next module a future test happens to mock. A general, mock-independent check is warranted because the bug class (an import whose target silently isn't part of the committed tree) can originate from any test's mock list, not just this one.
+
+### Requirements
+
+**Detection**
+
+- R1. A new automated check detects any local (repo-internal) Python import whose target file is missing from disk or not tracked by git — the exact failure mode behind `modules/video_regions.py` and `video_ai_editor/vr_video_view.py` in `0150a27`.
+- R2. The same check detects `from X import name` where `name` is neither defined at module scope in `X` nor bound there by one of `X`'s own top-level import statements (which covers re-export chains, since each link in the chain binds the name directly — see KTD4) — the failure mode behind `version.py`'s missing `__edition__` in `0150a27`.
+- R3. The check covers both absolute dotted imports (`import modules.foo`, `from modules import foo`) and relative imports (`from . import foo`, `from .foo import bar` — confirmed present in 5 files: `video_ai_editor/signal_timeline.py`, `video_ai_editor/edit_timeline.py`, `model_training/shared/visualization.py`, `model_training/shared/dataset.py`, `llm/llm_chat_widget.py`).
+
+**Integration**
+
+- R4. The check runs automatically as part of the existing `pytest -q` CI step (`.github/workflows/tests.yml`) — no new workflow file, job, or step.
+- R5. The check requires no new third-party dependency and no addition to `tests/conftest.py`'s heavy-dependency shim list — it must work from `requirements-dev.txt` (pytest + numpy) alone, matching the project's existing "5&nbsp;MB install, 5-second runtime" test-suite property (`tests/README.md:39-47`).
+
+**Reliability**
+
+- R6. The check produces zero false positives against the current codebase's legitimate patterns: relative imports, `try/except ImportError`-guarded local imports (confirmed present in `action_recognition.py`, `pipeline.py`, `llm/llm_chat_widget.py`, `main.py`), and any existing re-export idiom (`from .submodule import name`, bare `from . import submodule`, or an aliased `import x as y`) that binds a name at module top level.
+- R7. A future maintainer running the check manually (outside pytest) gets a human-readable report without needing to write a driver script.
+- R8. Local-root detection does not misclassify an installed third-party package as a repo-internal module solely because a same-named directory exists at repo root — confirmed live collision risk: `packaging/` (holding `packaging/pyinstaller-hooks/hook-optimum.py`) shares its name with the widely-used third-party `packaging` PyPI package.
+
+### Scope Boundaries
+
+- **Deferred to Follow-Up Work:** wiring the checker into a local pre-commit hook. The checker is built as an importable module with a CLI entrypoint (U4) specifically so this is a thin follow-up, not a redesign — but it is not committed to in this plan.
+- **Outside this plan:** broader pipeline test coverage. ~74 of 84 tracked `.py` files currently have zero direct test coverage (`tests/README.md`'s own "Phase 0" framing); this plan deliberately narrows to the missing-module bug class only, not a general coverage push.
+- **Known limitation, not a defect:** a re-export whose intermediate file exposes the name only via a wildcard import (`from .b import *`) is treated as unverifiable and skipped rather than flagged, since the set of names a `*` exposes isn't visible without recursively resolving the wildcard's own target. Genuinely dynamic import patterns (`importlib.import_module`, `__import__()`, string-based imports) are also out of scope — confirmed absent from the codebase today (see Sources & Research). If either is introduced later, this is a gap to revisit, not a bug in this plan. (`try/except ImportError`-guarded imports are explicitly NOT in this category — see KTD5.)
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1 — Static AST parsing, not runtime import.** The checker parses source with `ast` and never executes target modules. Rejected alternative A: a runtime smoke-import test extending `tests/conftest.py`'s shim list to cover `PySide6` and anything else `main.py`/GUI code pulls in — reintroduces the exact shim-maintenance burden this plan exists to remove. Rejected alternative B: an off-the-shelf linter (`ruff`/`pyflakes` F821 undefined-name checks, `mypy`). These check whether a name resolves in-process; none of them check whether the resolved file is *git-tracked* — R1's exact bug class (a file present on the author's machine but never committed) is invisible to a linter running on that same machine, since the file exists locally and imports resolve fine there. A linter could partially help with R2 (undefined symbols) but not R1 (the primary failure mode), and would add a new dependency this plan's R5 explicitly avoids.
+- **KTD2 — Local-root detection is dynamic, not a hardcoded allowlist, with an explicit third-party-collision guard.** A name is a "local root" if `<repo_root>/<name>.py` exists, or `<repo_root>/<name>/` exists and contains at least one `.py` file anywhere in its tree (handles both regular packages with `__init__.py` — `video_ai_editor`, `llm`, `model_training` — and implicit namespace packages without one — `modules`, `tools`, `training`, confirmed via direct check). Self-updating as the repo grows; avoids the drift a hardcoded list would accumulate. **Collision guard (R8):** before accepting a candidate root, check whether the name also resolves to an installed distribution when the repo root is temporarily removed from `sys.path` (e.g. via `importlib.util.find_spec`); if it does, treat the name as third-party, not local, and exclude it from `local_roots`. This is not a hardcoded exclusion list — it re-derives correctly if the repo ever gains or loses a same-named third-party dependency. Confirmed live case: `packaging/` (holds only `packaging/pyinstaller-hooks/hook-optimum.py`) collides with the third-party `packaging` PyPI package.
+- **KTD3 — Checker logic lives in `tools/check_local_imports.py`, not inline in a test file.** `tools/` is the project's existing home for standalone utilities (`export_clip_ov.py`, `labeler.py`, `scrape_listing_probe.py`). Building the checker as an importable module with a `run_check()` entrypoint plus a CLI wrapper (U4) means the same logic serves the pytest gate now and a future pre-commit hook later, at zero extra design cost — it's a thin follow-up (deferred, per Scope Boundaries), not a rewrite.
+- **KTD4 — A target file's "defined names" include names bound by its own top-level import statements, not just `def`/`class`/assignment.** Top-level symbol collection for a target file gathers `FunctionDef`/`AsyncFunctionDef`/`ClassDef`/`Assign`/`AnnAssign` names **plus** any name bound by a top-level `Import`/`ImportFrom` statement in that same file — using `alias.asname` when present, else `alias.name`'s last segment. This single rule covers `from .submodule import name` (binds `name`), bare `from . import submodule` (binds `submodule`), and `import x as y` (binds `y`) uniformly, whether the target is `__init__.py` or an ordinary module — no special-casing by file type, and no separate "hop" logic needed: the binding is visible directly in the target file's own AST. A symbol re-exported through two or more files (e.g. `a/__init__.py` does `from .b import name`, and `b.py` itself does `from .c import name`) still resolves in one pass, because `name` is bound directly in `a/__init__.py`'s AST regardless of where `b.py` originally got it — deeper chains are not chased into `b.py` or `c.py`, which is the plan's one documented resolution boundary (see Scope Boundaries).
+- **KTD5 — Only genuinely dynamic import patterns are out of detection scope.** `importlib.import_module`, `__import__()`, and other string-based imports are invisible to `ast.parse` and are not analyzed. A `try/except ImportError` around a normal `import X` / `from X import Y` statement is **not** in this category — the import statement is a regular AST node regardless of the surrounding control flow, so the checker parses and verifies it exactly like an unguarded import. This pattern is confirmed present today in `action_recognition.py:28` (`from modules.device_utils import detect_best_device`), `pipeline.py:47-48` (`from modules.transcript import ...`, `from modules.transcript_srt import ...`), `llm/llm_chat_widget.py:39` (`from .llm_timeline_bridge import TimelineBridge`), and `main.py:1905` (`from video_ai_editor.face_identity import FaceIdentityBank`) — all four resolve correctly today and must continue to under R6. Wildcard imports (`from X import *`) are handled: the target file's tracked-and-exists check still applies, but no symbol-level check runs (unverifiable by definition, since the consumed names aren't named in the import statement).
+
+### Assumptions
+
+These are inferred design bets, not decisions the user was asked to confirm (this plan was written in pipeline mode from an in-session brainstorm dialogue that reached scope agreement but not a final confirmed synthesis):
+
+- The checker scans the full tracked-file universe (`git ls-files '*.py'`) rather than a diff-scoped subset — this is a repo-health gate, not a per-PR incremental check, so it should catch pre-existing violations anywhere in the tree, not just newly changed files.
+- `models/` (bundled model-weight directory) is correctly excluded from local-root detection because it contains no `.py` files — no special-casing needed, verified as a natural consequence of KTD2's root-detection rule rather than an explicit exclusion.
+- The CLI entrypoint (U4) is in-scope for this plan (not deferred) because it costs nothing beyond exposing `run_check()` that U1-U3 already build, and directly enables the deferred pre-commit follow-up without a future redesign.
+- `repo_root` resolves via `git rev-parse --show-toplevel` (both for the pytest test and the CLI), not a hardcoded relative path from the checker module's own location — keeps behavior correct if `tools/check_local_imports.py` is ever moved.
+- `git ls-files` failure (missing `git` binary, or the working directory isn't a git checkout) is a real, reachable failure mode for R7's manual/CLI use case, not just a theoretical one — `run_check()` catches `FileNotFoundError` and a non-zero return code from the subprocess call and raises a single clear message (e.g. "not a git repository or git not found") instead of letting a raw traceback surface, satisfying R7's "human-readable report" promise even in this path.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["git ls-files '*.py'"] --> B[Parse each tracked file to AST]
+  B --> C["Extract local imports\n(absolute dotted + relative)"]
+  C --> D[Resolve each import\nto a candidate file path]
+  D --> E{File exists on disk\nAND git-tracked?}
+  E -->|no| V1["Violation:\nuntracked-or-missing-file"]
+  E -->|yes| F{Named symbol bound\nin target's own AST?}
+  F -->|no, and not wildcard| V2["Violation:\nundefined-symbol"]
+  F -->|yes, or wildcard| G[No violation]
+```
+
+Pipeline stages map directly to Implementation Units: A-C is U1, D-F is U2, the pytest wiring around this pipeline is U3, and the CLI presentation layer is U4.
+
+---
+
+## Implementation Units
+
+### U1. Local-root detection and import extraction
+
+**Goal:** Enumerate local (repo-internal) import targets from every git-tracked `.py` file's AST — both absolute dotted imports and relative imports — without executing any code.
+
+**Requirements:** R1, R3, R5, R8
+
+**Dependencies:** none
+
+**Files:**
+- `tools/check_local_imports.py` (new)
+- `tests/test_check_local_imports.py` (new)
+
+**Approach:** Implement `enumerate_local_roots(repo_root) -> set[str]` per KTD2, including the collision guard: for each candidate root name, skip it if `importlib.util.find_spec(name)` succeeds with the repo root temporarily removed from `sys.path` (third-party match). Implement `extract_local_imports(tree, importing_file, local_roots) -> list[LocalImport]` walking `ast.Import` and `ast.ImportFrom` nodes: for `ast.Import`, treat each dotted `alias.name` as local if its first segment is in `local_roots`; for `ast.ImportFrom` with `level == 0`, treat as local under the same first-segment test, capturing imported symbol names or a wildcard flag; for `level > 0` (relative), resolve relative to the importing file's own package directory using `level` — always local by definition. The walk visits every `Import`/`ImportFrom` node in the module regardless of nesting inside `try`/`except`/`if` blocks — control flow does not hide a statement from `ast.walk`. Get the tracked-file universe via one `subprocess.run(["git", "ls-files", "*.py"], cwd=repo_root)` call, not per-file; wrap the call so a missing `git` binary or non-git working directory raises one clear error instead of a raw traceback.
+
+**Patterns to follow:** No existing AST-parsing code in this repo — this is greenfield. Follow the project's flat single-module style (one `tools/check_local_imports.py`, not a new package) and `tests/conftest.py`'s pattern of stdlib-only test dependencies.
+
+**Test scenarios:**
+- Happy path: `import modules.foo` recognized as local when `modules` is a known root.
+- Happy path: `from modules import foo, bar` captures both symbol names.
+- Edge case: `from modules.foo import *` sets a wildcard flag with no symbol list.
+- Edge case: `from . import foo` and `from .foo import bar` resolve relative to a given importing file path.
+- Edge case: `import numpy` / `from os import path` are correctly excluded (not local roots).
+- Edge case: `from pipeline import run_highlighter` inside `main.py` is recognized as local (root-level sibling module, not a subpackage).
+- Edge case: `from modules.device_utils import detect_best_device` wrapped in `try: ... except ImportError:` (mirrors `action_recognition.py:28`) is extracted identically to an unguarded import — the walk does not special-case or skip nodes inside exception handlers.
+- Edge case: a candidate root name that also resolves to an installed third-party distribution (simulate with a fixture package, or use the real `packaging/` collision) is excluded from `local_roots` by the collision guard.
+- Edge case: `enumerate_local_roots` raises one clear, catchable error (not a raw `subprocess.CalledProcessError`/`FileNotFoundError` traceback) when `git` is unavailable or the directory isn't a git checkout.
+
+**Verification:** All listed scenarios pass as unit tests against `ast.parse`'d source strings (no real filesystem or git repo required for most scenarios; the collision-guard and git-unavailable scenarios use a fixture directory and a monkeypatched `subprocess.run` respectively).
+
+---
+
+### U2. Resolution and violation detection
+
+**Goal:** For each local import from U1, resolve it to an expected file path and verify it against the git-tracked set and (for named symbols) against the target file's defined names.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** U1
+
+**Files:**
+- `tools/check_local_imports.py` (extends)
+- `tests/test_check_local_imports.py` (extends)
+
+**Approach:** Implement `resolve_and_verify(local_imports, tracked_files) -> list[Violation]`. Dotted `a.b.c` resolves to candidate paths `a/b/c.py` or `a/b/c/__init__.py`; relative imports resolve via the importing file's directory and `level`. `Violation(kind, importing_file, lineno, detail)` with `kind` in `{"untracked-or-missing-file", "undefined-symbol"}`. Accept the tracked-file set as a parameter (don't reshell to `git` per import) so tests can inject a fake set without a real git repo. For symbol checks, `ast.parse` each target file once (cache per file) and collect its top-level defined names per KTD4: `FunctionDef`/`AsyncFunctionDef`/`ClassDef`/`Assign`/`AnnAssign` names, plus any name bound by a top-level `Import`/`ImportFrom` statement in that same file (`alias.asname` when present, else the bound name). No separate re-export "hop" step is needed — a re-exported name is already in the target file's own binding set by this rule.
+
+**Test scenarios:**
+- Happy path: import target exists and is in the tracked set -> no violation.
+- Failure path (mirrors `0150a27`'s `video_regions.py`/`vr_video_view.py`): import target file absent from disk entirely -> `untracked-or-missing-file` violation.
+- Failure path (the "exists on disk but untracked" sub-case, the actual `0150a27` mechanism): target file present on disk but absent from the injected tracked-file set -> `untracked-or-missing-file` violation.
+- Failure path (mirrors `0150a27`'s `__edition__` bug): `from version import __edition__` where the target's AST has no top-level `__edition__` assignment -> `undefined-symbol` violation.
+- Happy path: symbol resolves via `from .submodule import name` inside `pkg/__init__.py` when consumer does `from pkg import name` (mirrors `llm/llm_chat_widget.py:39`'s `from .llm_timeline_bridge import TimelineBridge` pattern).
+- Happy path: symbol resolves via a bare `from . import submodule` inside `pkg/__init__.py` when consumer does `from pkg import submodule`.
+- Happy path: symbol resolves via an aliased `import x as y` inside the target file when consumer does `from target import y`.
+- Edge case: wildcard import never produces an `undefined-symbol` violation, but its target's tracked/exists check still runs.
+- Edge case: a symbol re-exported through two hops (`a/__init__.py` does `from .b import name`; consumer does `from a import name`) resolves correctly in one pass, without inspecting `b.py` at all, because `name` is bound directly in `a/__init__.py`'s own top-level bindings.
+
+**Verification:** All listed scenarios pass; violations carry enough detail (`file:line`, kind, target) to be actionable without re-running the checker interactively.
+
+---
+
+### U3. Pytest wiring — full-repo assertion
+
+**Goal:** Wire U1+U2 into a pytest test that runs against the real repository and fails with an actionable message if any violation exists.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `tools/check_local_imports.py` (extends)
+- `tests/test_local_import_completeness.py` (new)
+
+**Approach:** Add `run_check(repo_root) -> list[Violation]` to `tools/check_local_imports.py`, composing U1 and U2: resolve `repo_root`, get the tracked-file universe, parse each tracked file to AST, call `extract_local_imports` for each, then `resolve_and_verify` over the combined result. `tests/test_local_import_completeness.py` adds a single test function `test_no_local_import_violations()` calling `run_check(repo_root)` against the real tree and asserting the returned violation list is empty. Format any violations into the assertion message (`file:line -- kind -- detail`, one per line) so a CI failure is diagnosable from the log alone. No `conftest.py` changes — stdlib `ast`/`subprocess`/`pathlib` only, per R5.
+
+**Test scenarios:**
+- Happy path: `test_no_local_import_violations` passes against the current, confirmed-clean repo state — this is the production regression-prevention assertion itself.
+- `Test expectation:` no additional synthetic scenarios needed here beyond the live-repo run; the checker's own correctness (false positive / false negative behavior) is proven by U1/U2's meta-tests.
+
+**Verification:** `pytest tests/test_local_import_completeness.py -q` passes; the existing `pytest -q` CI command picks it up automatically with no workflow changes (confirmed: `.github/workflows/tests.yml` runs `pytest -q` with no test-path filtering).
+
+---
+
+### U4. CLI entrypoint for manual / future pre-commit use
+
+**Goal:** Add a minimal CLI entrypoint to `tools/check_local_imports.py` so a contributor (or a future pre-commit hook, per Scope Boundaries) can run the same check manually with human-readable output.
+
+**Requirements:** R7
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- `tools/check_local_imports.py` (extends)
+
+**Approach:** `if __name__ == "__main__":` block that calls the same `run_check()` used by U3, prints one line per violation (`file:line -- kind -- detail`), and exits 1 if any violations exist, exits 0 with a short "no violations" message otherwise.
+
+**Test scenarios:**
+- Happy path: invoking the CLI (as a subprocess, or by calling its main function directly) against the real clean tree exits 0 and prints a "no violations" message.
+- Failure path: invoking the CLI against a fixture tree seeded with a known violation exits 1 and prints that violation's `file:line -- kind -- detail` line. This is the one behavior U4 adds beyond U1-U3 (the exit-code branch), and it is the exact mechanism a future pre-commit hook would depend on to block a commit — an inverted or dropped exit code here would fail silently for that use case.
+
+**Verification:** `python tools/check_local_imports.py` run manually from the repo root exits 0 on the clean tree and prints a clear one-line summary; the exit-1 fixture scenario is covered by an automated test, not manual-only verification.
+
+---
+
+## Verification Contract
+
+| Command | Applicability | Gate |
+|---|---|---|
+| `pytest -q` | All units | Existing CI command (`.github/workflows/tests.yml`); must stay green, including the two new test files, with zero new entries in `requirements-dev.txt` or `tests/conftest.py`. |
+| `pytest tests/test_check_local_imports.py tests/test_local_import_completeness.py -q` | U1-U3 | Scoped check during development; proves the checker's own logic (meta-tests) and its result against the live repo (integration test) independently. |
+| `python tools/check_local_imports.py` | U4 | Manual smoke check; nonzero exit only when a real violation exists. |
+
+---
+
+## Definition of Done
+
+- **Global:** `pytest -q` is green, including `tests/test_check_local_imports.py` and `tests/test_local_import_completeness.py`. No changes to `.github/workflows/tests.yml`, `requirements.txt`, `requirements-dev.txt`, or `tests/conftest.py`.
+- **U1/U2:** Every test scenario listed under U1 and U2 passes, including both `0150a27`-mirroring failure paths and the re-export/wildcard edge cases.
+- **U3:** `test_no_local_import_violations` passes against the live repository tree.
+- **U4:** `python tools/check_local_imports.py` runs cleanly from the repo root with a human-readable summary, and its exit-0/exit-1 branches are covered by an automated test against fixture trees, not manual verification alone.
+- **Cleanup:** No stray scratch files or dead-end fixtures left outside `tests/`; any fixture source strings/files used by U1/U2's meta-tests live as proper test fixtures, not temp-directory leftovers.
+
+---
+
+## Sources & Research
+
+- `0150a27b0b66fc34513a66790d616038d518cca7` ("fix: restore missing modules that broke a fresh clone") — the bug this plan guards against. Added `modules/video_regions.py`, `video_ai_editor/vr_video_view.py`, and `version.py`'s `__edition__`.
+- `tests/test_pipeline_legacy_imports.py:34-44` — the existing test that imports `pipeline.py` but explicitly mocks out `modules.motion_scene_detect_optimized` (the module whose real import pulled in the missing `modules.video_regions`), which is why CI did not catch the original bug despite running from a genuine fresh clone (`actions/checkout@v4`).
+- `tests/conftest.py:37-62` — the current heavy-dependency shim list (`cv2`, `torch`, `whisper`, `googletrans`, `ultralytics`, `openvino`, and others). This plan's checker needs none of these; it never imports target modules.
+- `.github/workflows/tests.yml` — full job is `checkout` -> `setup-python@3.12` -> `pip install -r requirements-dev.txt` -> `pytest -q`. Confirms a new file under `tests/` runs automatically with no workflow edit.
+- `tests/README.md:39-60` — the project's own "5&nbsp;MB install, 5-second runtime" test-suite constraint and its "no new heavy deps without shimming" rule, both satisfied by this plan's stdlib-only approach.
+- Repo-wide import/root scan performed during planning: 84 tracked `.py` files, 42 unique local dotted-import targets, all currently resolving to tracked files; zero `tools.*`/`training.*` package-style imports found (those dirs are script-only today); relative imports confirmed present in exactly 5 files (`video_ai_editor/signal_timeline.py`, `video_ai_editor/edit_timeline.py`, `model_training/shared/visualization.py`, `model_training/shared/dataset.py`, `llm/llm_chat_widget.py`); package-root `__init__.py` presence confirmed mixed (`video_ai_editor`, `llm`, `model_training` have one; `modules`, `tools`, `training` do not, i.e. implicit namespace packages) — both cases must be handled by KTD2's root detection.
+- Per-directory tracked `.py` file counts (verified via `git ls-files '<dir>/*.py' | wc -l`, sums to the 84 total above): `modules` 17, `video_ai_editor` 20, `llm` 6, `tools` 3, `model_training` 16, `training` 2, `tests` 9, `packaging` 1, repo-root 10.
+- `try/except ImportError`-guarded local imports (a pattern the plan's Stop Conditions originally, incorrectly, treated as unanalyzable) confirmed present at `action_recognition.py:28`, `pipeline.py:47-48`, `llm/llm_chat_widget.py:39`, and `main.py:1905` — all resolve correctly today; see KTD5 for why these are not actually a static-analysis blind spot.
+- `packaging/pyinstaller-hooks/hook-optimum.py` is the repo's only file under `packaging/`, confirming the R8/KTD2 name-collision risk against the third-party `packaging` PyPI package.
+- `from pipeline import run_highlighter` occurs in `main.py` (lines 528, 2226, 3497), not in `object_recognition.py` as an earlier draft of this plan's U1 test scenarios stated; `object_recognition.py` imports `from modules.device_utils import resolve_device` instead.

--- a/tests/test_check_local_imports.py
+++ b/tests/test_check_local_imports.py
@@ -121,6 +121,16 @@ def _make_repo(tmp_path: Path, layout: dict[str, str]) -> Path:
     return tmp_path
 
 
+def _init_git_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
+        cwd=repo,
+        check=True,
+    )
+
+
 def test_enumerate_local_roots_finds_root_files_and_packages(tmp_path):
     # Deliberately fictional names -- this repo's own real top-level names
     # (pipeline, modules, ...) are already on sys.path via how pytest
@@ -334,13 +344,7 @@ def test_run_check_clean_fixture_tree_reports_no_violations(tmp_path):
             "gadgets/foo.py": "def bar():\n    pass\n",
         },
     )
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
-    subprocess.run(
-        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
-        cwd=repo,
-        check=True,
-    )
+    _init_git_repo(repo)
     assert run_check(repo) == []
 
 
@@ -354,13 +358,7 @@ def test_run_check_flags_untracked_target(tmp_path):
             "gadgets/__init__.py": "",  # registers `gadgets` as a local root
         },
     )
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
-    subprocess.run(
-        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
-        cwd=repo,
-        check=True,
-    )
+    _init_git_repo(repo)
     violations = run_check(repo)
     assert len(violations) == 1
     assert violations[0].kind == "untracked-or-missing-file"
@@ -369,16 +367,6 @@ def test_run_check_flags_untracked_target(tmp_path):
 # ---------------------------------------------------------------------------
 # U4: CLI exit-code behavior
 # ---------------------------------------------------------------------------
-
-
-def _init_git_repo(repo: Path) -> None:
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
-    subprocess.run(
-        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
-        cwd=repo,
-        check=True,
-    )
 
 
 def _run_cli(repo: Path) -> subprocess.CompletedProcess:

--- a/tests/test_check_local_imports.py
+++ b/tests/test_check_local_imports.py
@@ -1,0 +1,419 @@
+"""Unit and meta-tests for tools/check_local_imports.py.
+
+Covers U1 (local-root detection + import extraction) and U2 (resolution +
+violation detection) scenarios from the plan, plus U4's CLI exit-code
+behavior. These tests exercise the checker's own logic against synthetic
+fixtures -- they do not assert anything about the real repository tree
+(that is tests/test_local_import_completeness.py's job).
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.check_local_imports import (
+    GitError,
+    enumerate_local_roots,
+    extract_local_imports,
+    get_tracked_py_files,
+    resolve_and_verify,
+    run_check,
+)
+
+
+# ---------------------------------------------------------------------------
+# U1: extract_local_imports
+# ---------------------------------------------------------------------------
+
+LOCAL_ROOTS = {"modules", "video_ai_editor", "llm", "pipeline"}
+
+
+def _imports_from_source(source: str, importing_file: str = "app.py", roots=LOCAL_ROOTS):
+    tree = ast.parse(source, filename=importing_file)
+    return extract_local_imports(tree, importing_file, roots)
+
+
+def test_absolute_dotted_import_recognized_as_local():
+    imports = _imports_from_source("import modules.foo\n")
+    assert len(imports) == 1
+    assert imports[0].kind == "module"
+    assert imports[0].package_path == "modules/foo"
+    assert imports[0].symbols is None
+    assert not imports[0].is_wildcard
+
+
+def test_from_import_captures_multiple_symbols():
+    imports = _imports_from_source("from modules import foo, bar\n")
+    assert len(imports) == 1
+    assert imports[0].kind == "from"
+    assert imports[0].package_path == "modules"
+    assert imports[0].symbols == ("foo", "bar")
+
+
+def test_wildcard_import_sets_wildcard_flag_no_symbol_list():
+    imports = _imports_from_source("from modules.foo import *\n")
+    assert len(imports) == 1
+    assert imports[0].is_wildcard is True
+    assert imports[0].symbols is None
+
+
+def test_relative_imports_resolve_against_importing_file_path():
+    imports = _imports_from_source(
+        "from . import foo\nfrom .bar import baz\n",
+        importing_file="llm/llm_chat_widget.py",
+    )
+    assert len(imports) == 2
+    # Bare `from . import foo`: package_path is the current package itself,
+    # `foo` is a candidate submodule or symbol within it.
+    assert imports[0].package_path == "llm"
+    assert imports[0].symbols == ("foo",)
+    # `from .bar import baz`: package_path is the named submodule `llm/bar`.
+    assert imports[1].package_path == "llm/bar"
+    assert imports[1].symbols == ("baz",)
+
+
+def test_third_party_imports_excluded():
+    imports = _imports_from_source("import numpy\nfrom os import path\n")
+    assert imports == []
+
+
+def test_root_level_sibling_module_import_recognized_as_local():
+    # Mirrors main.py's `from pipeline import run_highlighter` -- a
+    # root-level sibling module, not a subpackage.
+    imports = _imports_from_source(
+        "from pipeline import run_highlighter\n", importing_file="main.py"
+    )
+    assert len(imports) == 1
+    assert imports[0].package_path == "pipeline"
+    assert imports[0].symbols == ("run_highlighter",)
+
+
+def test_try_except_guarded_import_extracted_identically_to_unguarded():
+    # Mirrors action_recognition.py:28 -- a real, confirmed pattern.
+    source = (
+        "try:\n"
+        "    from modules.device_utils import detect_best_device\n"
+        "    TORCH_AVAILABLE = True\n"
+        "except ImportError:\n"
+        "    TORCH_AVAILABLE = False\n"
+    )
+    imports = _imports_from_source(source, importing_file="action_recognition.py")
+    assert len(imports) == 1
+    assert imports[0].package_path == "modules/device_utils"
+    assert imports[0].symbols == ("detect_best_device",)
+
+
+# ---------------------------------------------------------------------------
+# U1: enumerate_local_roots
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: Path, layout: dict[str, str]) -> Path:
+    for rel_path, content in layout.items():
+        full = tmp_path / rel_path
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def test_enumerate_local_roots_finds_root_files_and_packages(tmp_path):
+    # Deliberately fictional names -- this repo's own real top-level names
+    # (pipeline, modules, ...) are already on sys.path via how pytest
+    # imports this very test module, which would make them collide with
+    # themselves under the collision guard regardless of tmp_path's content.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "widgetmod.py": "x = 1\n",
+            "gadgets/foo.py": "x = 1\n",  # no __init__.py -- namespace package
+            "sprockets/__init__.py": "",
+            "sprockets/bar.py": "x = 1\n",
+        },
+    )
+    roots = enumerate_local_roots(repo)
+    assert roots == {"widgetmod", "gadgets", "sprockets"}
+
+
+def test_enumerate_local_roots_excludes_dirs_with_no_py_files(tmp_path):
+    repo = _make_repo(tmp_path, {"models/weights.bin": "binary\n"})
+    roots = enumerate_local_roots(repo)
+    assert roots == set()
+
+
+def test_enumerate_local_roots_collision_guard_excludes_third_party_name(tmp_path):
+    # `packaging` is a real, near-universally-installed third-party
+    # distribution (a transitive dependency of setuptools/pip). A repo
+    # directory named `packaging/` containing only an unrelated script
+    # must NOT be treated as a local import root.
+    pytest.importorskip("packaging", reason="packaging must be installed for this test")
+    repo = _make_repo(
+        tmp_path, {"packaging/pyinstaller-hooks/hook-optimum.py": "x = 1\n"}
+    )
+    roots = enumerate_local_roots(repo)
+    assert "packaging" not in roots
+
+
+def test_enumerate_local_roots_raises_clear_error_when_git_unavailable(tmp_path, monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(GitError):
+        get_tracked_py_files(tmp_path)
+
+
+def test_get_tracked_py_files_raises_clear_error_when_not_a_git_repo(tmp_path):
+    with pytest.raises(GitError):
+        get_tracked_py_files(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# U2: resolve_and_verify
+# ---------------------------------------------------------------------------
+
+
+def _local_import(package_path, symbols=None, is_wildcard=False, importing_file="app.py", lineno=1):
+    from tools.check_local_imports import LocalImport
+
+    return LocalImport(
+        importing_file=importing_file,
+        lineno=lineno,
+        kind="module" if symbols is None and not is_wildcard else "from",
+        package_path=package_path,
+        symbols=symbols,
+        is_wildcard=is_wildcard,
+    )
+
+
+def test_resolve_and_verify_no_violation_when_target_tracked_and_exists(tmp_path):
+    repo = _make_repo(tmp_path, {"modules/foo.py": "def bar():\n    pass\n"})
+    tracked = {"modules/foo.py"}
+    imp = _local_import("modules/foo", symbols=("bar",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
+def test_untracked_or_missing_violation_when_file_absent_from_disk(tmp_path):
+    repo = tmp_path
+    tracked: set[str] = set()
+    imp = _local_import("modules/video_regions")
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert len(violations) == 1
+    assert violations[0].kind == "untracked-or-missing-file"
+
+
+def test_untracked_or_missing_violation_when_present_on_disk_but_not_tracked(tmp_path):
+    # The actual 0150a27 mechanism: file exists locally but was never
+    # `git add`ed, so it's absent from the tracked-file set.
+    repo = _make_repo(tmp_path, {"modules/video_regions.py": "def f():\n    pass\n"})
+    tracked: set[str] = set()  # deliberately does NOT include the file present on disk
+    imp = _local_import("modules/video_regions")
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert len(violations) == 1
+    assert violations[0].kind == "untracked-or-missing-file"
+
+
+def test_undefined_symbol_violation_mirrors_edition_bug(tmp_path):
+    repo = _make_repo(tmp_path, {"version.py": "__version__ = '0.8.1'\n"})
+    tracked = {"version.py"}
+    imp = _local_import("version", symbols=("__edition__",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert len(violations) == 1
+    assert violations[0].kind == "undefined-symbol"
+    assert "__edition__" in violations[0].detail
+
+
+def test_symbol_resolves_via_submodule_reexport_in_init(tmp_path):
+    # Mirrors llm/llm_chat_widget.py:39's
+    # `from .llm_timeline_bridge import TimelineBridge` pattern.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "pkg/__init__.py": "from .submodule import name\n",
+            "pkg/submodule.py": "def name():\n    pass\n",
+        },
+    )
+    tracked = {"pkg/__init__.py", "pkg/submodule.py"}
+    imp = _local_import("pkg", symbols=("name",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
+def test_symbol_resolves_via_bare_submodule_reexport(tmp_path):
+    repo = _make_repo(
+        tmp_path,
+        {
+            "pkg/__init__.py": "from . import submodule\n",
+            "pkg/submodule.py": "x = 1\n",
+        },
+    )
+    tracked = {"pkg/__init__.py", "pkg/submodule.py"}
+    imp = _local_import("pkg", symbols=("submodule",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
+def test_symbol_resolves_via_aliased_import(tmp_path):
+    repo = _make_repo(tmp_path, {"target.py": "import os as y\n"})
+    tracked = {"target.py"}
+    imp = _local_import("target", symbols=("y",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
+def test_wildcard_import_never_produces_undefined_symbol_but_checks_target(tmp_path):
+    repo = _make_repo(tmp_path, {"modules/foo.py": "x = 1\n"})
+    tracked = {"modules/foo.py"}
+    imp = _local_import("modules/foo", is_wildcard=True)
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []  # target exists and is tracked; no symbol check runs
+
+    imp_missing = _local_import("modules/missing", is_wildcard=True)
+    violations = resolve_and_verify([imp_missing], tracked, repo)
+    assert len(violations) == 1
+    assert violations[0].kind == "untracked-or-missing-file"
+
+
+def test_two_hop_reexport_resolves_without_inspecting_second_file(tmp_path):
+    # a/__init__.py does `from .b import name`; consumer does `from a import name`.
+    # `name` is bound directly in a/__init__.py's own top-level bindings,
+    # so this resolves without needing to look inside b.py at all.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "a/__init__.py": "from .b import name\n",
+            "a/b.py": "name = 42\n",
+        },
+    )
+    tracked = {"a/__init__.py", "a/b.py"}
+    imp = _local_import("a", symbols=("name",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
+def test_conditionally_defined_top_level_name_resolves(tmp_path):
+    # Mirrors llm/llm_module.py:34-37's
+    # `try: import cv2; HAS_CV2 = True \n except ImportError: HAS_CV2 = False`
+    # -- a name assigned only inside a module-level try/except is still a
+    # real top-level binding.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "llm/llm_module.py": (
+                "try:\n"
+                "    HAS_CV2 = True\n"
+                "except ImportError:\n"
+                "    HAS_CV2 = False\n"
+            )
+        },
+    )
+    tracked = {"llm/llm_module.py"}
+    imp = _local_import("llm/llm_module", symbols=("HAS_CV2",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# run_check integration (fixture-tree level, not the real repo)
+# ---------------------------------------------------------------------------
+
+
+def test_run_check_clean_fixture_tree_reports_no_violations(tmp_path):
+    # Fictional root name (see collision-guard note above) so this test
+    # genuinely proves the clean-import path, not a false pass caused by
+    # `gadgets`/`modules` self-colliding with this project's own package.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "app.py": "from gadgets.foo import bar\n",
+            "gadgets/foo.py": "def bar():\n    pass\n",
+        },
+    )
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
+        cwd=repo,
+        check=True,
+    )
+    assert run_check(repo) == []
+
+
+def test_run_check_flags_untracked_target(tmp_path):
+    # Fictional root name -- avoids self-colliding with this project's own
+    # real `modules` package, which is on sys.path during this test run.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "app.py": "from gadgets.missing_module import bar\n",
+            "gadgets/__init__.py": "",  # registers `gadgets` as a local root
+        },
+    )
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
+        cwd=repo,
+        check=True,
+    )
+    violations = run_check(repo)
+    assert len(violations) == 1
+    assert violations[0].kind == "untracked-or-missing-file"
+
+
+# ---------------------------------------------------------------------------
+# U4: CLI exit-code behavior
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-q", "-m", "init"],
+        cwd=repo,
+        check=True,
+    )
+
+
+def _run_cli(repo: Path) -> subprocess.CompletedProcess:
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "check_local_imports.py"
+    return subprocess.run(
+        [sys.executable, str(module_path)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_exits_zero_on_clean_tree(tmp_path):
+    repo = _make_repo(
+        tmp_path,
+        {
+            "app.py": "from gadgets.foo import bar\n",
+            "gadgets/foo.py": "def bar():\n    pass\n",
+        },
+    )
+    _init_git_repo(repo)
+    result = _run_cli(repo)
+    assert result.returncode == 0
+    assert "no violations" in result.stdout.lower()
+
+
+def test_cli_exits_one_on_violation(tmp_path):
+    repo = _make_repo(
+        tmp_path,
+        {
+            "app.py": "from gadgets.missing import bar\n",
+            "gadgets/__init__.py": "",  # registers `gadgets` as a local root
+        },
+    )
+    _init_git_repo(repo)
+    result = _run_cli(repo)
+    assert result.returncode == 1
+    assert "untracked-or-missing-file" in result.stdout

--- a/tests/test_check_local_imports.py
+++ b/tests/test_check_local_imports.py
@@ -208,6 +208,18 @@ def test_resolve_and_verify_no_violation_when_target_tracked_and_exists(tmp_path
     assert violations == []
 
 
+def test_resolve_and_verify_no_violation_for_plain_module_import(tmp_path):
+    # kind="module" (a plain `import modules.foo`, no symbols) success path --
+    # distinct from the "from"-kind case above, which is what
+    # _local_import(..., symbols=(...)) actually constructs.
+    repo = _make_repo(tmp_path, {"modules/foo.py": "x = 1\n"})
+    tracked = {"modules/foo.py"}
+    imp = _local_import("modules/foo")
+    assert imp.kind == "module"
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert violations == []
+
+
 def test_untracked_or_missing_violation_when_file_absent_from_disk(tmp_path):
     repo = tmp_path
     tracked: set[str] = set()
@@ -328,6 +340,28 @@ def test_conditionally_defined_top_level_name_resolves(tmp_path):
     assert violations == []
 
 
+def test_plain_module_cannot_have_submodules_even_if_sibling_dir_matches(tmp_path):
+    # A tracked plain module `modules/foo.py` coexisting with an unrelated
+    # same-stem directory `modules/foo/bar.py` must NOT make
+    # `from modules.foo import bar` look valid: Python only attempts a
+    # submodule import when the parent is an actual package, and a plain
+    # module can never have real submodules. At real runtime this raises
+    # ImportError; the checker must flag it as undefined-symbol, not pass it.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "modules/foo.py": "x = 1\n",
+            "modules/foo/bar.py": "bar = 42\n",
+        },
+    )
+    tracked = {"modules/foo.py", "modules/foo/bar.py"}
+    imp = _local_import("modules/foo", symbols=("bar",))
+    violations = resolve_and_verify([imp], tracked, repo)
+    assert len(violations) == 1
+    assert violations[0].kind == "undefined-symbol"
+    assert "plain module" in violations[0].detail
+
+
 # ---------------------------------------------------------------------------
 # run_check integration (fixture-tree level, not the real repo)
 # ---------------------------------------------------------------------------
@@ -362,6 +396,47 @@ def test_run_check_flags_untracked_target(tmp_path):
     violations = run_check(repo)
     assert len(violations) == 1
     assert violations[0].kind == "untracked-or-missing-file"
+
+
+def test_run_check_skips_non_utf8_file_instead_of_crashing(tmp_path):
+    # A tracked .py file with invalid UTF-8 bytes (plausible on this
+    # Windows-developed project, e.g. via an editor's default "ANSI" save)
+    # must be skipped like any other unparseable file, not raise
+    # UnicodeDecodeError out of run_check() and crash the whole checker.
+    repo = _make_repo(
+        tmp_path,
+        {
+            "app.py": "from gadgets.foo import bar\n",
+            "gadgets/foo.py": "def bar():\n    pass\n",
+        },
+    )
+    (repo / "bad_encoding.py").write_bytes(b"x = 1  # latin1 byte: \xe9\n")
+    _init_git_repo(repo)
+    violations = run_check(repo)  # must not raise
+    assert violations == []
+
+
+def test_run_check_handles_non_ascii_tracked_filename(tmp_path):
+    # git C-quotes/octal-escapes non-ASCII tracked paths by default
+    # (core.quotepath=true); without countering that, get_tracked_py_files
+    # would return a quoted string that never matches the real path,
+    # silently dropping the file from analysis. Built from a single shared
+    # variable (rather than two separately-typed literals) so the test can't
+    # spuriously fail from unrelated Unicode normalization (NFC/NFD) drift
+    # between two occurrences of the same accented character.
+    module_stem = "caf" + "é"  # "café", explicit NFC codepoint
+    rel_path = f"gadgets/{module_stem}.py"
+    repo = _make_repo(
+        tmp_path,
+        {
+            rel_path: "def bar():\n    pass\n",
+            "app.py": f"from gadgets.{module_stem} import bar\n",
+        },
+    )
+    _init_git_repo(repo)
+    tracked = get_tracked_py_files(repo)
+    assert rel_path in tracked
+    assert run_check(repo) == []
 
 
 # ---------------------------------------------------------------------------
@@ -404,4 +479,11 @@ def test_cli_exits_one_on_violation(tmp_path):
     _init_git_repo(repo)
     result = _run_cli(repo)
     assert result.returncode == 1
-    assert "untracked-or-missing-file" in result.stdout
+
+
+def test_cli_exits_one_with_clear_message_outside_a_git_repo(tmp_path):
+    # main()'s `except GitError` branch -- no git init this time.
+    result = _run_cli(tmp_path)
+    assert result.returncode == 1
+    assert "check_local_imports:" in result.stdout
+    assert "not a git repository" in result.stdout.lower()

--- a/tests/test_local_import_completeness.py
+++ b/tests/test_local_import_completeness.py
@@ -1,0 +1,22 @@
+"""Production regression-prevention assertion: no local import in this
+repository targets a file that is missing or untracked, and no imported
+symbol is undefined. This is the safeguard for the bug class fixed in
+commit 0150a27 -- see docs/plans/2026-07-08-001-test-local-import-audit-plan.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.check_local_imports import run_check
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_no_local_import_violations():
+    violations = run_check(REPO_ROOT)
+    if violations:
+        detail = "\n".join(str(v) for v in violations)
+        raise AssertionError(
+            f"{len(violations)} local import violation(s) found:\n{detail}"
+        )

--- a/tools/check_local_imports.py
+++ b/tools/check_local_imports.py
@@ -1,0 +1,378 @@
+"""Static, AST-based audit of local (repo-internal) Python imports.
+
+Verifies that every local import in the repository resolves to a
+git-tracked file, and that any named symbol it imports is actually
+defined there. This is the safeguard for the bug class fixed in commit
+0150a27: a file that exists on the author's machine but was never
+`git add`ed, so a fresh clone breaks on import.
+
+Never imports the target modules it checks -- everything here is static
+`ast` parsing, so this module has no dependency beyond the standard
+library and works without the project's heavy ML install.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from dataclasses import dataclass
+from importlib.machinery import PathFinder
+from pathlib import Path
+
+
+class GitError(RuntimeError):
+    """git is unavailable, or the target directory isn't a git checkout."""
+
+
+@dataclass(frozen=True)
+class LocalImport:
+    importing_file: str  # repo-relative, forward slashes
+    lineno: int
+    kind: str  # "module" (plain `import a.b.c`) or "from" (`from a.b import c, d`)
+    package_path: str  # repo-relative slash path with no extension: the submodule
+    #   chain for kind="module", or the package/module being imported-from for kind="from"
+    symbols: tuple[str, ...] | None  # kind="from" only; None for wildcard or kind="module"
+    is_wildcard: bool = False
+
+
+@dataclass(frozen=True)
+class Violation:
+    kind: str  # "untracked-or-missing-file" | "undefined-symbol"
+    importing_file: str
+    lineno: int
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.importing_file}:{self.lineno} -- {self.kind} -- {self.detail}"
+
+
+def _run_git_ls_files(repo_root: Path, pattern: str) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", pattern],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise GitError("git not found -- is git installed and on PATH?") from exc
+    if result.returncode != 0:
+        raise GitError(
+            f"'git ls-files {pattern}' failed in {repo_root} "
+            f"(not a git repository?): {result.stderr.strip()}"
+        )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def get_tracked_py_files(repo_root: Path) -> set[str]:
+    """Repo-relative paths (forward slashes) of every git-tracked .py file."""
+    return set(_run_git_ls_files(repo_root, "*.py"))
+
+
+def _is_third_party(name: str, repo_root: Path) -> bool:
+    """True if `name` resolves to an installed distribution somewhere on
+    sys.path OTHER than repo_root (KTD2 collision guard). Uses PathFinder
+    directly against a filtered path list rather than mutating global
+    sys.path/sys.modules, so this has no side effects on caller state and
+    is not affected by whatever already imported this process's own
+    package (which would otherwise self-collide when repo_root differs
+    from the real project root, e.g. under a temp-directory test)."""
+    resolved_root = repo_root.resolve()
+    search_path = [
+        p for p in sys.path if p and Path(p).resolve() != resolved_root
+    ]
+    try:
+        spec = PathFinder.find_spec(name, path=search_path)
+    except (ImportError, ValueError):
+        spec = None
+    return spec is not None
+
+
+def enumerate_local_roots(repo_root: Path) -> set[str]:
+    """Top-level names at repo_root that are local (repo-internal) import
+    roots: a `<name>.py` file, or a `<name>/` directory containing at
+    least one `.py` file anywhere in its tree -- excluding any candidate
+    that also resolves to an installed third-party distribution."""
+    roots: set[str] = set()
+    for entry in repo_root.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.is_file() and entry.suffix == ".py":
+            roots.add(entry.stem)
+        elif entry.is_dir():
+            if any(entry.rglob("*.py")):
+                roots.add(entry.name)
+    return {name for name in roots if not _is_third_party(name, repo_root)}
+
+
+def _relative_package_path(importing_file: str, level: int, module: str | None) -> str:
+    """Repo-relative directory/module path a relative import's dots resolve
+    to -- the package itself (bare `from . import X`) when `module` is
+    None, or that package's named submodule (`from .sub import X`)."""
+    parts = importing_file.split("/")
+    package_parts = parts[:-1]  # directory containing importing_file
+    climb = level - 1
+    if climb > 0:
+        package_parts = (
+            package_parts[: len(package_parts) - climb] if climb <= len(package_parts) else []
+        )
+    prefix = "/".join(package_parts)
+    if module:
+        return f"{prefix}/{module.replace('.', '/')}" if prefix else module.replace(".", "/")
+    return prefix
+
+
+def extract_local_imports(
+    tree: ast.AST, importing_file: str, local_roots: set[str]
+) -> list[LocalImport]:
+    """Walk every Import/ImportFrom node in `tree` (regardless of nesting
+    inside try/except/if -- control flow never hides a statement from
+    ast.walk) and return the ones that target a local root."""
+    results: list[LocalImport] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                first_seg = alias.name.split(".")[0]
+                if first_seg in local_roots:
+                    results.append(
+                        LocalImport(
+                            importing_file=importing_file,
+                            lineno=node.lineno,
+                            kind="module",
+                            package_path=alias.name.replace(".", "/"),
+                            symbols=None,
+                        )
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                if not node.module:
+                    continue
+                first_seg = node.module.split(".")[0]
+                if first_seg not in local_roots:
+                    continue
+                package_path = node.module.replace(".", "/")
+            else:
+                package_path = _relative_package_path(importing_file, node.level, node.module)
+
+            is_wildcard = any(alias.name == "*" for alias in node.names)
+            if is_wildcard:
+                results.append(
+                    LocalImport(
+                        importing_file=importing_file,
+                        lineno=node.lineno,
+                        kind="from",
+                        package_path=package_path,
+                        symbols=None,
+                        is_wildcard=True,
+                    )
+                )
+            else:
+                symbols = tuple(alias.name for alias in node.names)
+                results.append(
+                    LocalImport(
+                        importing_file=importing_file,
+                        lineno=node.lineno,
+                        kind="from",
+                        package_path=package_path,
+                        symbols=symbols,
+                    )
+                )
+    return results
+
+
+_SCOPE_TRANSPARENT = (ast.Try, ast.If, ast.While, ast.For, ast.AsyncFor, ast.With, ast.AsyncWith)
+
+
+def _collect_top_level_names(stmts: list[ast.stmt]) -> set[str]:
+    """Names bound at module level: def/class names, plain assignment
+    targets, and names bound by import statements (KTD4). Recurses into
+    module-level control flow (try/if/while/for/with) since those don't
+    introduce a new scope in Python, but never into a function/class body."""
+    names: set[str] = set()
+    for node in stmts:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                names.add(node.target.id)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                names.add(alias.asname or alias.name)
+        elif isinstance(node, _SCOPE_TRANSPARENT):
+            for field in ("body", "orelse", "finalbody"):
+                names |= _collect_top_level_names(getattr(node, field, []) or [])
+            for handler in getattr(node, "handlers", []) or []:
+                names |= _collect_top_level_names(handler.body)
+        # Function/class/lambda bodies are a different scope -- never recursed into.
+    return names
+
+
+def _file_candidates(path: str) -> tuple[str, str]:
+    """The two file forms a repo-relative module/package path could take."""
+    return f"{path}.py", f"{path}/__init__.py"
+
+
+def resolve_and_verify(
+    local_imports: list[LocalImport], tracked_files: set[str], repo_root: Path
+) -> list[Violation]:
+    """Resolve each local import and verify it against `tracked_files`
+    (git-tracked-ness) and, for named symbols, the target's own top-level
+    bindings. For `from X import Y`, Y may be either a submodule of X or a
+    symbol defined in X itself -- both are tried, matching how Python's
+    import system actually resolves `from package import name`."""
+    violations: list[Violation] = []
+    top_level_cache: dict[str, set[str] | None] = {}
+
+    def top_level_names(tracked_path: str) -> set[str] | None:
+        if tracked_path in top_level_cache:
+            return top_level_cache[tracked_path]
+        full = repo_root / tracked_path
+        try:
+            source = full.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=tracked_path)
+        except (OSError, SyntaxError):
+            top_level_cache[tracked_path] = None
+            return None
+        names = _collect_top_level_names(tree.body)
+        top_level_cache[tracked_path] = names
+        return names
+
+    def resolved_file(path: str) -> str | None:
+        as_module, as_package = _file_candidates(path)
+        if as_module in tracked_files:
+            return as_module
+        if as_package in tracked_files:
+            return as_package
+        return None
+
+    def has_namespace_contents(path: str) -> bool:
+        prefix = path + "/"
+        return any(t.startswith(prefix) for t in tracked_files)
+
+    for imp in local_imports:
+        if imp.kind == "module":
+            if resolved_file(imp.package_path) is None:
+                as_module, as_package = _file_candidates(imp.package_path)
+                violations.append(
+                    Violation(
+                        kind="untracked-or-missing-file",
+                        importing_file=imp.importing_file,
+                        lineno=imp.lineno,
+                        detail=f"target '{imp.package_path}' resolves to neither "
+                        f"'{as_module}' nor '{as_package}' in the git-tracked file set",
+                    )
+                )
+            continue
+
+        # kind == "from"
+        package_file = resolved_file(imp.package_path)
+
+        if imp.is_wildcard:
+            if package_file is None and not has_namespace_contents(imp.package_path):
+                violations.append(
+                    Violation(
+                        kind="untracked-or-missing-file",
+                        importing_file=imp.importing_file,
+                        lineno=imp.lineno,
+                        detail=f"wildcard-imported package '{imp.package_path}' has no "
+                        "tracked package file and no tracked contents",
+                    )
+                )
+            continue
+
+        for symbol in imp.symbols or ():
+            submodule_candidate = f"{imp.package_path}/{symbol}"
+            if resolved_file(submodule_candidate) is not None:
+                continue  # valid submodule import (e.g. `from modules import debug_console`)
+
+            if package_file is not None:
+                names = top_level_names(package_file)
+                if names is None or symbol in names:
+                    continue  # valid symbol import, or target unparseable (not this checker's failure mode)
+                violations.append(
+                    Violation(
+                        kind="undefined-symbol",
+                        importing_file=imp.importing_file,
+                        lineno=imp.lineno,
+                        detail=f"'{symbol}' is not defined at module scope in '{package_file}', "
+                        f"and '{submodule_candidate}.py' is not a tracked submodule either",
+                    )
+                )
+                continue
+
+            violations.append(
+                Violation(
+                    kind="untracked-or-missing-file",
+                    importing_file=imp.importing_file,
+                    lineno=imp.lineno,
+                    detail=f"neither submodule '{submodule_candidate}' nor a package file for "
+                    f"'{imp.package_path}' was found in the git-tracked file set",
+                )
+            )
+
+    return violations
+
+
+def run_check(repo_root: Path) -> list[Violation]:
+    """Compose the full pipeline: enumerate roots, extract every local
+    import from every tracked .py file, resolve and verify each."""
+    tracked_files = get_tracked_py_files(repo_root)
+    local_roots = enumerate_local_roots(repo_root)
+
+    all_imports: list[LocalImport] = []
+    for tracked_path in sorted(tracked_files):
+        full = repo_root / tracked_path
+        try:
+            source = full.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=tracked_path)
+        except (OSError, SyntaxError):
+            continue
+        all_imports.extend(extract_local_imports(tree, tracked_path, local_roots))
+
+    return resolve_and_verify(all_imports, tracked_files, repo_root)
+
+
+def _resolve_repo_root() -> Path:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise GitError("git not found -- is git installed and on PATH?") from exc
+    if result.returncode != 0:
+        raise GitError(f"not a git repository: {result.stderr.strip()}")
+    return Path(result.stdout.strip())
+
+
+def main() -> int:
+    try:
+        repo_root = _resolve_repo_root()
+        violations = run_check(repo_root)
+    except GitError as exc:
+        print(f"check_local_imports: {exc}")
+        return 1
+
+    if not violations:
+        print("check_local_imports: no violations found.")
+        return 0
+
+    for violation in violations:
+        print(str(violation))
+    print(f"check_local_imports: {len(violations)} violation(s) found.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_local_imports.py
+++ b/tools/check_local_imports.py
@@ -70,18 +70,14 @@ def get_tracked_py_files(repo_root: Path) -> set[str]:
     return set(_run_git_ls_files(repo_root, "*.py"))
 
 
-def _is_third_party(name: str, repo_root: Path) -> bool:
+def _is_third_party(name: str, search_path: list[str]) -> bool:
     """True if `name` resolves to an installed distribution somewhere on
-    sys.path OTHER than repo_root (KTD2 collision guard). Uses PathFinder
-    directly against a filtered path list rather than mutating global
-    sys.path/sys.modules, so this has no side effects on caller state and
-    is not affected by whatever already imported this process's own
-    package (which would otherwise self-collide when repo_root differs
-    from the real project root, e.g. under a temp-directory test)."""
-    resolved_root = repo_root.resolve()
-    search_path = [
-        p for p in sys.path if p and Path(p).resolve() != resolved_root
-    ]
+    `search_path`. Uses PathFinder directly against a caller-filtered path
+    list rather than mutating global sys.path/sys.modules, so this has no
+    side effects on caller state and is not affected by whatever already
+    imported this process's own package (which would otherwise self-collide
+    when the checked repo differs from the real project root, e.g. under a
+    temp-directory test)."""
     try:
         spec = PathFinder.find_spec(name, path=search_path)
     except (ImportError, ValueError):
@@ -103,7 +99,9 @@ def enumerate_local_roots(repo_root: Path) -> set[str]:
         elif entry.is_dir():
             if any(entry.rglob("*.py")):
                 roots.add(entry.name)
-    return {name for name in roots if not _is_third_party(name, repo_root)}
+    resolved_root = repo_root.resolve()
+    search_path = [p for p in sys.path if p and Path(p).resolve() != resolved_root]
+    return {name for name in roots if not _is_third_party(name, search_path)}
 
 
 def _relative_package_path(importing_file: str, level: int, module: str | None) -> str:
@@ -186,7 +184,7 @@ _SCOPE_TRANSPARENT = (ast.Try, ast.If, ast.While, ast.For, ast.AsyncFor, ast.Wit
 
 def _collect_top_level_names(stmts: list[ast.stmt]) -> set[str]:
     """Names bound at module level: def/class names, plain assignment
-    targets, and names bound by import statements (KTD4). Recurses into
+    targets, and names bound by import statements. Recurses into
     module-level control flow (try/if/while/for/with) since those don't
     introduce a new scope in Python, but never into a function/class body."""
     names: set[str] = set()
@@ -223,26 +221,37 @@ def _file_candidates(path: str) -> tuple[str, str]:
 
 
 def resolve_and_verify(
-    local_imports: list[LocalImport], tracked_files: set[str], repo_root: Path
+    local_imports: list[LocalImport],
+    tracked_files: set[str],
+    repo_root: Path,
+    parsed_trees: dict[str, ast.AST] | None = None,
 ) -> list[Violation]:
     """Resolve each local import and verify it against `tracked_files`
     (git-tracked-ness) and, for named symbols, the target's own top-level
     bindings. For `from X import Y`, Y may be either a submodule of X or a
     symbol defined in X itself -- both are tried, matching how Python's
-    import system actually resolves `from package import name`."""
+    import system actually resolves `from package import name`.
+
+    `parsed_trees` lets a caller that already parsed a tracked file (e.g.
+    `run_check`, which parses every tracked file once to extract its
+    imports) share that tree instead of this function re-parsing it from
+    disk when the same file is also a symbol-import target."""
     violations: list[Violation] = []
+    parsed_trees = parsed_trees or {}
     top_level_cache: dict[str, set[str] | None] = {}
 
     def top_level_names(tracked_path: str) -> set[str] | None:
         if tracked_path in top_level_cache:
             return top_level_cache[tracked_path]
-        full = repo_root / tracked_path
-        try:
-            source = full.read_text(encoding="utf-8")
-            tree = ast.parse(source, filename=tracked_path)
-        except (OSError, SyntaxError):
-            top_level_cache[tracked_path] = None
-            return None
+        tree = parsed_trees.get(tracked_path)
+        if tree is None:
+            full = repo_root / tracked_path
+            try:
+                source = full.read_text(encoding="utf-8")
+                tree = ast.parse(source, filename=tracked_path)
+            except (OSError, SyntaxError):
+                top_level_cache[tracked_path] = None
+                return None
         names = _collect_top_level_names(tree.body)
         top_level_cache[tracked_path] = names
         return names
@@ -330,6 +339,7 @@ def run_check(repo_root: Path) -> list[Violation]:
     local_roots = enumerate_local_roots(repo_root)
 
     all_imports: list[LocalImport] = []
+    parsed_trees: dict[str, ast.AST] = {}
     for tracked_path in sorted(tracked_files):
         full = repo_root / tracked_path
         try:
@@ -337,9 +347,10 @@ def run_check(repo_root: Path) -> list[Violation]:
             tree = ast.parse(source, filename=tracked_path)
         except (OSError, SyntaxError):
             continue
+        parsed_trees[tracked_path] = tree
         all_imports.extend(extract_local_imports(tree, tracked_path, local_roots))
 
-    return resolve_and_verify(all_imports, tracked_files, repo_root)
+    return resolve_and_verify(all_imports, tracked_files, repo_root, parsed_trees)
 
 
 def _resolve_repo_root() -> Path:

--- a/tools/check_local_imports.py
+++ b/tools/check_local_imports.py
@@ -47,22 +47,46 @@ class Violation:
         return f"{self.importing_file}:{self.lineno} -- {self.kind} -- {self.detail}"
 
 
-def _run_git_ls_files(repo_root: Path, pattern: str) -> list[str]:
+_GIT_TIMEOUT_SECONDS = 30
+
+
+def _run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run a git subcommand, translating process-level failures (missing
+    binary, timeout) into GitError. Does NOT check the return code -- a
+    non-zero exit is a normal outcome for some callers (e.g. "not a git
+    repo") and is handled by each call site with its own message."""
     try:
-        result = subprocess.run(
-            ["git", "ls-files", pattern],
-            cwd=repo_root,
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
             capture_output=True,
-            text=True,
+            # Explicit UTF-8, not text=True's locale-based decoding: git
+            # writes tracked (non-quoted, via core.quotepath=false) paths as
+            # UTF-8 regardless of platform, but the OS locale encoding can
+            # differ (e.g. cp1252 on Windows) -- decoding non-ASCII output
+            # with the wrong codec silently corrupts filenames instead of
+            # raising, so paths would mismatch tracked_files elsewhere.
+            encoding="utf-8",
+            timeout=_GIT_TIMEOUT_SECONDS,
         )
     except FileNotFoundError as exc:
         raise GitError("git not found -- is git installed and on PATH?") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GitError(f"'git {' '.join(args)}' timed out after {_GIT_TIMEOUT_SECONDS}s") from exc
+
+
+def _run_git_ls_files(repo_root: Path, pattern: str) -> list[str]:
+    # `-c core.quotepath=false -z`: without these, git C-quotes/octal-escapes
+    # any tracked path containing a non-ASCII byte (e.g. "caf\303\251/foo.py"
+    # instead of "café/foo.py"), which would never match the real
+    # repo-relative path this checker joins against repo_root elsewhere.
+    result = _run_git(["-c", "core.quotepath=false", "ls-files", "-z", pattern], cwd=repo_root)
     if result.returncode != 0:
         raise GitError(
             f"'git ls-files {pattern}' failed in {repo_root} "
             f"(not a git repository?): {result.stderr.strip()}"
         )
-    return [line for line in result.stdout.splitlines() if line]
+    return [line for line in result.stdout.split("\0") if line]
 
 
 def get_tracked_py_files(repo_root: Path) -> set[str]:
@@ -249,7 +273,7 @@ def resolve_and_verify(
             try:
                 source = full.read_text(encoding="utf-8")
                 tree = ast.parse(source, filename=tracked_path)
-            except (OSError, SyntaxError):
+            except (OSError, SyntaxError, UnicodeDecodeError):
                 top_level_cache[tracked_path] = None
                 return None
         names = _collect_top_level_names(tree.body)
@@ -299,22 +323,36 @@ def resolve_and_verify(
                 )
             continue
 
+        # A plain module (resolved via its `.py` form, not `/__init__.py`) can
+        # never have real submodules -- Python only attempts a submodule
+        # import when the parent is an actual package. Without this guard, a
+        # coincidental sibling directory sharing the module's stem (e.g. a
+        # tracked `modules/foo.py` alongside an unrelated `modules/foo/bar.py`)
+        # would make `from modules.foo import bar` look valid here even
+        # though it raises ImportError at real runtime.
+        package_is_plain_module = package_file is not None and package_file == f"{imp.package_path}.py"
+
         for symbol in imp.symbols or ():
             submodule_candidate = f"{imp.package_path}/{symbol}"
-            if resolved_file(submodule_candidate) is not None:
+            if not package_is_plain_module and resolved_file(submodule_candidate) is not None:
                 continue  # valid submodule import (e.g. `from modules import debug_console`)
 
             if package_file is not None:
                 names = top_level_names(package_file)
                 if names is None or symbol in names:
                     continue  # valid symbol import, or target unparseable (not this checker's failure mode)
+                submodule_note = (
+                    f"'{package_file}' is a plain module and cannot have submodules"
+                    if package_is_plain_module
+                    else f"and '{submodule_candidate}.py' is not a tracked submodule either"
+                )
                 violations.append(
                     Violation(
                         kind="undefined-symbol",
                         importing_file=imp.importing_file,
                         lineno=imp.lineno,
                         detail=f"'{symbol}' is not defined at module scope in '{package_file}', "
-                        f"and '{submodule_candidate}.py' is not a tracked submodule either",
+                        f"{submodule_note}",
                     )
                 )
                 continue
@@ -345,7 +383,7 @@ def run_check(repo_root: Path) -> list[Violation]:
         try:
             source = full.read_text(encoding="utf-8")
             tree = ast.parse(source, filename=tracked_path)
-        except (OSError, SyntaxError):
+        except (OSError, SyntaxError, UnicodeDecodeError):
             continue
         parsed_trees[tracked_path] = tree
         all_imports.extend(extract_local_imports(tree, tracked_path, local_roots))
@@ -354,14 +392,7 @@ def run_check(repo_root: Path) -> list[Violation]:
 
 
 def _resolve_repo_root() -> Path:
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError as exc:
-        raise GitError("git not found -- is git installed and on PATH?") from exc
+    result = _run_git(["rev-parse", "--show-toplevel"])
     if result.returncode != 0:
         raise GitError(f"not a git repository: {result.stderr.strip()}")
     return Path(result.stdout.strip())


### PR DESCRIPTION
 ## Summary

Adds a static local import completeness check that runs as part of the existing pytest suite.

The checker validates that repo-internal Python imports resolve to git-tracked files and that named imports reference symbols actually defined or re-exported by the target module. This is intended to catch fresh-clone failures where code works locally because an imported file exists on a developer machine but was never committed.

## Problem

Commit `0150a27` fixed a fresh-clone breakage caused by missing or incomplete local imports:

* `modules.video_regions`
* `video_ai_editor.vr_video_view`
* `from version import __edition__`

CI did not catch this because the relevant import path was mocked in an existing test. This PR adds a general, mock-independent check so similar issues are caught automatically in the future.

## Changes

* Added `tools/check_local_imports.py`

  * Parses tracked Python files using `ast`
  * Detects local absolute and relative imports
  * Verifies imported modules resolve to existing git-tracked files
  * Verifies named imports are defined or re-exported at module scope
  * Includes a CLI entrypoint for manual usage

* Added checker unit tests

  * Covers absolute imports
  * Covers relative imports
  * Covers wildcard imports
  * Covers missing files
  * Covers untracked files
  * Covers undefined imported symbols
  * Covers re-export patterns

* Added full-repo pytest integration

  * Runs automatically through the existing `pytest -q` CI command
  * Requires no CI workflow changes
  * Requires no new dependencies
  * Requires no new heavy-dependency shims

## Verification

Run:

```bash
pytest -q
```

Optional manual check:

```bash
python tools/check_local_imports.py
```

## Notes

This check is intentionally static and does not execute imported modules. Dynamic imports such as `importlib.import_module()` or `__import__()` are out of scope.
