### PR TITLE
wip(report): port the clip and chapter narration from the Pro tree

### DIFF
--- a/main.py
+++ b/main.py
@@ -2657,6 +2657,81 @@ class VideoHighlighterGUI(QWidget):
             "browser and sendable to a client. A matching .json holds the same data.")
         bbox_layout.addWidget(self.why_report_chk)
 
+        # The narration passes, which used to be reachable only from the
+        # AI-summary menu after the run had already finished. On by default: a
+        # clip on footage nobody speaks over has nothing on its card about what
+        # is in the picture, and a chapter is the same question one scale up.
+        self.narrate_clips_chk = QCheckBox("…and describe each clip")
+        self.narrate_clips_chk.setChecked(
+            visualization_cfg.get("narrate_clips", True))
+        self.narrate_clips_chk.setToolTip(
+            "Asks the chosen model to describe every kept clip from its frames,\n"
+            "at the end of the run.\n\n"
+            "One model call per clip, so it adds a minute or two — and it needs a\n"
+            "model with a vision half. The clip cards are written from the\n"
+            "pictures; without this they carry only what was measured.")
+        bbox_layout.addWidget(self.narrate_clips_chk)
+
+        # The label carries the warning the default cannot: this is the slowest
+        # thing the report does, so the user needs to know what it costs at the
+        # moment they could turn it off, not after the run has spent it.
+        self.narrate_chapters_chk = QCheckBox("…and tell each chapter (slow)")
+        self.narrate_chapters_chk.setChecked(
+            visualization_cfg.get("narrate_chapters", True))
+        self.narrate_chapters_chk.setToolTip(
+            "Asks the chosen model to narrate every chapter of the video, at the\n"
+            "end of the run.\n\n"
+            "One model call per chapter — minutes, not seconds, and the slowest\n"
+            "pass here. A chapter can be told from its transcript, so this adds\n"
+            "least on footage that already has speech in it.")
+        bbox_layout.addWidget(self.narrate_chapters_chk)
+
+        for _chk in (self.narrate_clips_chk, self.narrate_chapters_chk):
+            # Both narrate the report, so neither means anything without one.
+            self.why_report_chk.toggled.connect(_chk.setEnabled)
+            _chk.setEnabled(self.why_report_chk.isChecked())
+
+        # Where the output folder is reachable over the network. A report read
+        # on a phone has dead players — a browser cannot reach a sibling file
+        # from a `content://` origin, nor seek one without HTTP range requests —
+        # and every figure on the page stays true, which is what makes that
+        # confusing rather than obviously broken. Given this, the page carries
+        # the address where it can be played.
+        self.serve_base_input = QLineEdit(
+            str(visualization_cfg.get("report_serve_base", "") or ""))
+        self.serve_base_input.setPlaceholderText("http://192.168.0.10:8000/")
+        self.serve_base_input.setToolTip(
+            "Optional. If you serve the output folder over HTTP, put its base URL\n"
+            "here and every report gets a link back to its playable self.\n\n"
+            "Leave empty for the usual behaviour. This only adds a link — it does\n"
+            "not start a server; see tools/serve_report.py for one that supports\n"
+            "the range requests seeking needs.")
+        self.why_report_chk.toggled.connect(self.serve_base_input.setEnabled)
+        self.serve_base_input.setEnabled(self.why_report_chk.isChecked())
+        bbox_layout.addWidget(QLabel("Served at (optional):"))
+        bbox_layout.addWidget(self.serve_base_input)
+
+        # The other half, and the one that survives with nothing running: where
+        # the *footage* lives on a share. A browser cannot play `smb://` — no
+        # browser implements the scheme — but tapping a link to one hands it to
+        # a player app, which is enough to check a moment. A share is mounted
+        # all day where an ad-hoc web server is not, so this is the fallback the
+        # HTTP link needs rather than a duplicate of it.
+        self.media_base_input = QLineEdit(
+            str(visualization_cfg.get("report_media_base", "") or ""))
+        self.media_base_input.setPlaceholderText("smb://192.168.0.10/movies/")
+        self.media_base_input.setToolTip(
+            "Optional. Where the video folder is reachable from other devices —\n"
+            "an SMB share, usually. Each clip then carries a link that opens the\n"
+            "source in a player app.\n\n"
+            "The position cannot survive the hand-off, so the clip opens at the\n"
+            "start and the link says which timestamp to seek to. Use the HTTP\n"
+            "field above instead when you want playback to land on the moment.")
+        self.why_report_chk.toggled.connect(self.media_base_input.setEnabled)
+        self.media_base_input.setEnabled(self.why_report_chk.isChecked())
+        bbox_layout.addWidget(QLabel("Video reachable at (optional):"))
+        bbox_layout.addWidget(self.media_base_input)
+
         bbox_box.setLayout(bbox_layout)
         advanced_layout.addWidget(bbox_box, 1, 1)
 
@@ -3887,6 +3962,7 @@ class VideoHighlighterGUI(QWidget):
             "auto_merge_gap": float(self.spin_auto_merge_gap.value()),
             "draw_object_boxes": self.bbox_objects_chk.isChecked(),
             "write_highlight_report": self.why_report_chk.isChecked(),
+            **self._report_config(),
             "draw_action_labels": self.bbox_actions_chk.isChecked(),
             "action_backend": self.action_backend_combo.currentData(),
             "r3d_model": self.r3d_model_combo.currentData(),
@@ -4261,6 +4337,7 @@ class VideoHighlighterGUI(QWidget):
             "visualization": {
                 "draw_object_boxes": self.bbox_objects_chk.isChecked(),
                 "write_highlight_report": self.why_report_chk.isChecked(),
+                **self._report_config(),
                 "draw_action_labels": self.bbox_actions_chk.isChecked(),
             },
             "avoid": {
@@ -5070,6 +5147,7 @@ class VideoHighlighterGUI(QWidget):
             "auto_merge_gap": float(self.spin_auto_merge_gap.value()),
             "draw_object_boxes": self.bbox_objects_chk.isChecked(),
             "write_highlight_report": self.why_report_chk.isChecked(),
+            **self._report_config(),
             "draw_action_labels": self.bbox_actions_chk.isChecked(),
             "action_backend": self.action_backend_combo.currentData(),
             "r3d_model": self.r3d_model_combo.currentData(),
@@ -5734,6 +5812,27 @@ class VideoHighlighterGUI(QWidget):
         if not entry:
             return ("ollama", "llama3")
         return (entry["backend"], entry["model"])
+
+    def _report_config(self):
+        """What the run needs to write the report the way this window is set up.
+
+        The model goes into the run's config rather than being read from
+        settings inside the pipeline, so that a run narrates with the model that
+        was chosen when it started — the menu can be used to pick a different
+        one while a long analysis is still going, and a run that changed model
+        halfway would be very hard to explain from the report afterwards.
+
+        Built in one place because three call sites assemble a config dict, and
+        three copies of these keys is three chances for one to be forgotten and
+        for the setting to appear to do nothing.
+        """
+        return {
+            "narrate_clips": self.narrate_clips_chk.isChecked(),
+            "narrate_chapters": self.narrate_chapters_chk.isChecked(),
+            "narration_model": self._active_llm_model() or {},
+            "report_serve_base": self.serve_base_input.text().strip(),
+            "report_media_base": self.media_base_input.text().strip(),
+        }
 
     def _llm_models(self):
         """Every configured model, oldest single-model setting folded in."""

--- a/modules/chapter_story.py
+++ b/modules/chapter_story.py
@@ -64,8 +64,44 @@ STORY_SYSTEM_PROMPT = (
     "recapping it."
 )
 
+# The same brief for a captioner, which cannot receive the one above: a model
+# trained to describe a picture and not to take instruction reproduces a
+# numbered rulebook instead of obeying it. See `modules.llm_models.is_captioner`
+# for where that was learned — plain imperative sentences, no numbering, no
+# format template to parrot back.
+#
+# Nothing is relaxed here. Every constraint the rulebook carries is carried by
+# this too; only the packaging differs, because the packaging is what leaked.
+CAPTIONER_SYSTEM_PROMPT = (
+    "Describe what happened in one stretch of a video, for someone who cannot "
+    "watch it. You are given measurements another tool made, everything that "
+    "was said, and sometimes frames.\n"
+    "Say who is present, what they are doing, and how it changes.\n"
+    "Write two to four plain sentences in the past tense. No headings, no "
+    "lists, no preamble.\n"
+    "Never write a number, a percentage or a time. They are printed beside "
+    "your words already.\n"
+    "Where you are guessing rather than reading something off, say so — "
+    "'appears to', 'seems to be'. Invent nothing that the material does not "
+    "mention.\n"
+    "Treat any expression label you are given as a guess by another tool, not "
+    "as what someone felt.\n"
+    "When you are shown what came before, continue from it without recapping "
+    "it.\n"
+    "If the material is too thin to say what happened, say only: Too little to "
+    "say what happened here."
+)
+
 STORY_TASK = ("Say what happened in this stretch of the video, as if telling "
               "someone who has not seen it.")
+
+
+def system_prompt_for(model_name: Optional[str]) -> str:
+    """The brief this model can actually receive."""
+    from modules.llm_models import is_captioner
+
+    return CAPTIONER_SYSTEM_PROMPT if is_captioner(model_name) \
+        else STORY_SYSTEM_PROMPT
 
 # A paragraph, not an essay. Each chapter's block already carries its
 # measurements and quotes; the prose is there to connect them, and at four
@@ -433,7 +469,8 @@ def trim_repetition(text: str) -> str:
     return " ".join(s.strip() for s in kept).strip()
 
 
-def _tell_one(llm, prompt: str, images: Optional[Sequence[str]]) -> str:
+def _tell_one(llm, prompt: str, images: Optional[Sequence[str]],
+              system: Optional[str] = None) -> str:
     """One call, with pictures when the model takes them.
 
     Falls back to text on any image-related failure rather than losing the
@@ -442,22 +479,23 @@ def _tell_one(llm, prompt: str, images: Optional[Sequence[str]]) -> str:
     """
     from modules.advisor import _generate
 
+    system = system or STORY_SYSTEM_PROMPT
     if images:
         try:
-            return llm.generate(prompt, system=STORY_SYSTEM_PROMPT,
+            return llm.generate(prompt, system=system,
                                 max_tokens=STORY_TOKENS,
                                 temperature=STORY_TEMPERATURE,
                                 images=list(images))
         except Exception as exc:
             print(f"⚠️ Chapter frames not used ({exc}); telling from text alone")
-    return _generate(llm, prompt, STORY_SYSTEM_PROMPT, STORY_TOKENS,
-                     STORY_TEMPERATURE)
+    return _generate(llm, prompt, system, STORY_TOKENS, STORY_TEMPERATURE)
 
 
 def tell(report: Mapping,
          *,
          llm,
          frames_fn: Optional[Callable] = None,
+         model_name: Optional[str] = None,
          log_fn=print,
          cancel_fn: Optional[Callable[[], bool]] = None) -> list[dict]:
     """Narrate every chapter in order. Returns the chapters, story attached.
@@ -471,6 +509,8 @@ def tell(report: Mapping,
     chapters = [dict(ch) for ch in (report.get("chapters") or [])]
     if not chapters or llm is None:
         return chapters
+
+    system = system_prompt_for(model_name)
 
     previous = None
     for index, ch in enumerate(chapters, start=1):
@@ -487,7 +527,7 @@ def tell(report: Mapping,
                 print(f"⚠️ Frames for chapter {index} failed: {exc}")
         try:
             text = (_tell_one(llm, chapter_prompt(report, ch, previous),
-                              images) or "").strip()
+                              images, system) or "").strip()
         except Exception as exc:
             log_fn(f"⚠️ Chapter {index} could not be told: {exc}")
             continue
@@ -558,8 +598,8 @@ def tell_report_file(json_path: str,
             log_fn("ℹ️ Source video not found beside the report — telling from "
                    "the transcript and the measurements alone.")
 
-    chapters = tell(report, llm=llm, frames_fn=frames_fn, log_fn=log_fn,
-                    cancel_fn=cancel_fn)
+    chapters = tell(report, llm=llm, frames_fn=frames_fn,
+                    model_name=model_name, log_fn=log_fn, cancel_fn=cancel_fn)
     told = [ch for ch in chapters if ch.get("story")]
     if not told:
         return 0

--- a/modules/clip_story.py
+++ b/modules/clip_story.py
@@ -1,0 +1,650 @@
+"""A paragraph per kept clip, read off the clip's own frames.
+
+:mod:`modules.chapter_story` closes this gap for a *chapter*: a stretch of
+several minutes, told mostly from what was said in it. That works, and on a
+video with a transcript it works well enough that the clip cards need nothing —
+each one already carries the lines spoken over it, and "said here" turns out to
+be most of what a reader wanted when they asked what a moment was.
+
+On footage with no speech there is nothing in that slot at all, and the
+difference between the two reports is stark. Everything under "The moments, in
+order" is still true — the movement burst, the level against the video's median,
+the classifier's reading — and none of it says what is on screen. A page that
+can describe a moment in six measured sentences without once mentioning what is
+in the picture is not a page that has explained the moment.
+
+So this asks the model that *can* see. One call per kept clip, a few frames
+spread across it, and the sentences the report already wrote about it — the same
+three commitments :mod:`modules.chapter_story` makes, for the same reasons:
+
+**It is given evidence, not asked to imagine.** The frames, the measured
+sentences, the detector's labels, anything said, and any notes a narration pass
+already wrote over this span. Nothing is asked for that the material does not
+contain.
+
+**It cannot introduce a figure.** Every number on the card was computed before
+this ran and is printed under the paragraph. The reading sits above the evidence
+it was written from, inside the same card, so a reader who doubts a sentence
+does not have to leave it.
+
+**It is labelled, in the record and on the page.** ``story`` on the segment,
+``clip_story`` on the report, and the words "read from this clip" on the card.
+
+Where it differs from the chapter pass
+--------------------------------------
+
+A chapter is minutes long and is told in order, each one handed what came
+before, because a run of chapters should read continuously. A clip is thirty
+seconds and its neighbour is often twenty minutes away, so there is nothing to
+continue *from* — the carry exists here only to stop fourteen cards opening with
+the same sentence, and it is the one thing the previous clip is used for.
+
+The other difference is what the frames are for. A chapter's frames are a
+sanity check on a paragraph the transcript could mostly have written; here they
+are the whole content, and the prompt says so. Frames are sampled across the
+clip rather than at its peak second precisely so the answer can be about what
+*changes* — which is the one thing the thumbnail already on the card cannot show,
+and generally what the clip was picked for.
+
+Cost
+----
+
+One vision call per kept clip: fourteen clips is a minute or two on a local
+model, against the hours a whole-video narration costs. That ratio is the reason
+this exists as its own pass rather than as a filter over
+:mod:`modules.moment_narration` — but when a narration *has* been run, its notes
+for these seconds are handed over as material, because a note written from a
+frame beats a second guess at the same frame.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import os
+from typing import Callable, Mapping, Optional, Sequence
+
+# The licence and its bounds, as in `chapter_story` — with rule 3 doing the work
+# that rule is not needed for there. The frames are the content of this answer,
+# and a model handed four pictures and a page of measurements will otherwise
+# write about the measurements, which the card already says better.
+CLIP_SYSTEM_PROMPT = (
+    "You are describing one short clip from a video, for someone who cannot "
+    "watch it. You are given a few frames taken across the clip, measurements "
+    "another tool made about it, and whatever was said in it.\n"
+    "Rules:\n"
+    "1. Write plain continuous prose, present tense, 2-4 sentences. No "
+    "headings, no bullet points, no preamble, no restating the question.\n"
+    "2. Never state a number, a percentage or a timestamp. They are printed "
+    "beside your paragraph already.\n"
+    "3. Say what is in the frames: who is present, where they are, what they "
+    "are doing. This is what the rest of the page cannot say, so it is what is "
+    "being asked for.\n"
+    "4. Where you are given more than one frame they are in order, a few "
+    "seconds apart. Say what changes between them — that is what the clip was "
+    "picked for, and what a single still cannot show.\n"
+    "5. Stay with what the material shows. Where you are inferring rather than "
+    "reading something off, say so plainly ('appears to', 'seems to be'). Do "
+    "not invent events, names or places that nothing mentions.\n"
+    "6. If the frames are too dark, too close or too few to make out, say that "
+    "in one sentence instead of filling the space.\n"
+    "7. Expression labels come from a five-class classifier that cannot tell a "
+    "performed expression from a felt one. Do not treat them as feelings.\n"
+    "8. When a previous clip is given, do not recap it and do not open the same "
+    "way; say what is different here.\n"
+    "9. When the run has flagged something here -- a detected label or a "
+    "composition rule -- neither ignore it nor repeat it as fact. Say whether "
+    "what you can see supports it, and attribute it to the run: 'the run "
+    "flagged X here, and the frames show / do not show Y'. If the frames "
+    "neither support nor contradict it, say exactly that. You were told it "
+    "fired, which is not the same as having seen it, so it is never your own "
+    "observation. This one sentence is worth more than another describing the "
+    "frames, because it is the only part of the page that can disagree with "
+    "the detector."
+)
+
+# The captioner's copy of the same brief — see
+# :data:`modules.chapter_story.CAPTIONER_SYSTEM_PROMPT` for why a second one
+# exists at all. Rule 9 survives the flattening as its own paragraph rather than
+# a clause: it is the only sentence on the page allowed to disagree with the
+# detector, and it is the first thing a shorter prompt loses.
+CAPTIONER_SYSTEM_PROMPT = (
+    "Describe one short clip from a video, for someone who cannot watch it. "
+    "You are given a few frames taken across it, measurements another tool "
+    "made, and whatever was said.\n"
+    "Say what is in the frames: who is present, where they are, what they are "
+    "doing. That is what the rest of the page cannot say.\n"
+    "The frames are in order, a few seconds apart. Say what changes between "
+    "them.\n"
+    "Write two to four plain sentences in the present tense. No headings, no "
+    "lists, no preamble.\n"
+    "Never write a number, a percentage or a time. They are printed beside "
+    "your words already.\n"
+    "Where you are guessing rather than reading something off, say so — "
+    "'appears to', 'seems to be'. Invent nothing that the material does not "
+    "mention.\n"
+    "Treat any expression label you are given as a guess by another tool, not "
+    "as what someone felt.\n"
+    "When you are shown the clip before this one, do not recap it and do not "
+    "open the same way. Say what is different here.\n"
+    "When you are told the run flagged something here, you were told it fired "
+    "— you did not see it fire. Say whether the frames support it and say who "
+    "claimed it: 'the run flagged X, and the frames show / do not show Y'. If "
+    "the frames neither support nor contradict it, say exactly that. Never "
+    "repeat it as your own observation.\n"
+    "If the frames are too dark, too close or too few to make out, say only: "
+    "Too little to see here."
+)
+
+CLIP_TASK = ("Say what this clip shows, as if telling someone who has not seen "
+             "it.")
+
+# Shorter than a chapter's. A clip is thirty seconds with one thing happening in
+# it, and past three sentences a model starts narrating the measurements it was
+# handed rather than the picture.
+CLIP_TOKENS = 200
+
+CLIP_TEMPERATURE = 0.8
+
+# Per-clip prompt budget. Smaller than a chapter's for the same reason a clip is
+# smaller than a chapter: there is simply less to say, and the frames are most
+# of the payload.
+MAX_CLIP_CHARS = 5000
+
+# How much of the previous clip is carried. Half a chapter's, because this is
+# only here to break the opening-sentence lock — a clip has no continuity with
+# its neighbour worth preserving, and more context is more chance of an error
+# from one card being restated as fact on the next.
+CARRY_CHARS = 200
+
+# Spread across the clip, not clustered at the peak. Four rather than the
+# chapter pass's three: a thirty-second span sampled four times is roughly every
+# seven seconds, which is close enough that a change between two of them is
+# legible as a change rather than as two unrelated pictures.
+FRAMES_PER_CLIP = 4
+
+# Notes from an earlier narration that fall inside a clip. Enough to establish
+# what was already observed across the span, few enough that they do not become
+# the answer — this pass is looking at the frames, not summarising a log.
+MAX_NOTES = 6
+
+# Lines of speech offered per clip. The card prints three and says how many more
+# there were; the prompt can afford all of a thirty-second clip's dialogue.
+MAX_SPEECH_LINES = 20
+
+
+def _clip_facts(report: Mapping, entry: Mapping) -> list:
+    """The measured sentences for one clip, as the card shows them.
+
+    Read through :mod:`modules.highlight_report` rather than assembled here, so
+    the prompt and the page cannot end up quoting different figures for one run
+    — the same rule :func:`modules.chapter_story._chapter_facts` follows.
+    """
+    try:
+        from modules.highlight_prose import clip_sections
+        from modules.highlight_report import _segment_readings
+
+        arc = report.get("expression_arc") or {}
+        valence = float((arc.get("valence") or {}).get("mean_all_read") or 0.0)
+        peers = [float(e.get("score") or 0.0)
+                 for e in (report.get("segments") or [])]
+        reading = _segment_readings(report).get(entry.get("index"))
+        lines = []
+        for heading, sentences in clip_sections(entry, reading, valence, peers):
+            for sentence in sentences:
+                lines.append(f"{heading}: {sentence}")
+        return lines
+    except Exception as exc:                       # pragma: no cover - defensive
+        print(f"⚠️ Clip facts skipped: {exc}")
+        return []
+
+
+def _labels_here(entry: Mapping) -> list:
+    """What the detector, the composition rules and the action model called it.
+
+    Named as three separate sources rather than merged into one list of words,
+    because they carry very different weight and a model given them flat treats
+    the 0.01-confidence action exactly as it treats the object that was measured
+    for the whole video.
+    """
+    lines = []
+    objects = [str(o) for o in (entry.get("objects") or [])]
+    if objects:
+        lines.append("The object detector labelled these at the peak second: "
+                     + ", ".join(objects) + ".")
+    events = [str(v) for v in (entry.get("events") or [])]
+    if events:
+        lines.append("The composition rules recognised: " + ", ".join(events)
+                     + ". These are combinations of the labels above, not a "
+                     "separate observation.")
+    actions = entry.get("actions") or []
+    if actions:
+        named = ", ".join(f'{a.get("name")} (confidence '
+                          f'{float(a.get("confidence") or 0.0):.2f})'
+                          for a in actions)
+        lines.append(f"The action model's best guesses: {named}. Its labels "
+                     f"come from a fixed everyday-activity vocabulary, so a low "
+                     f"confidence usually means it has no word for what is "
+                     f"happening. Ignore one that does not match the frames.")
+    return lines
+
+
+def _notes_here(report: Mapping, entry: Mapping) -> list:
+    """Notes an earlier narration pass wrote inside this clip, if there is one.
+
+    Free when it exists and absent when it does not, which is the ordinary case.
+    Offered as observation rather than as conclusion: each was written from one
+    frame by a model that could not see the others, and the whole point of
+    handing them over together is that this call can see the span they cover.
+    """
+    try:
+        # Looked up by name rather than imported outright, because this module
+        # is shared verbatim with an edition that has no per-frame narration and
+        # therefore no such file. A static `from modules import narration_notes`
+        # would be a promise this file cannot keep there — and the import
+        # checker is right to fail it, so the fix is to stop making the promise
+        # rather than to teach the checker about guards.
+        #
+        # Its absence is the edition boundary, not a fault, so it says nothing.
+        # Caught separately from the rest: a *real* fault below still gets its
+        # warning, which is the whole value of not widening this except.
+        import importlib
+
+        try:
+            narration_notes = importlib.import_module("modules.narration_notes")
+        except ImportError:
+            return []
+
+        path = str((report.get("video") or {}).get("path") or "")
+        entries = narration_notes.load(path)
+        if not entries:
+            return []
+        inside = narration_notes.within(
+            entries, [(float(entry.get("start") or 0.0),
+                       float(entry.get("end") or 0.0))])
+        return [" ".join(str(e.get("text") or "").split())
+                for e in inside[:MAX_NOTES]]
+    except Exception as exc:                       # pragma: no cover - defensive
+        print(f"⚠️ Narration notes skipped: {exc}")
+        return []
+
+
+def _speech_here(entry: Mapping) -> list:
+    """What was said over the clip, speaker first where one was identified."""
+    said = entry.get("speech") or {}
+    lines = []
+    for line in (said.get("lines") or [])[:MAX_SPEECH_LINES]:
+        who = f'{line["speaker"]}: ' if line.get("speaker") else ""
+        text = str(line.get("text") or "").strip()
+        if text:
+            lines.append(f"{who}{text}")
+    return lines
+
+
+def clip_prompt(report: Mapping, entry: Mapping,
+                previous: Optional[str] = None,
+                max_chars: int = MAX_CLIP_CHARS,
+                frame_count: int = 0) -> str:
+    """Everything the model is told about one clip.
+
+    ``frame_count`` is how many frames the model will actually be shown, which
+    is not always how many were sampled — see :func:`_frames_delivered`. It is
+    stated in the prompt because rule 4 asks what changes between them, and a
+    model handed one picture and told it has four will answer the question it
+    was asked rather than the one it can see.
+    """
+    segments = report.get("segments") or []
+    video = report.get("video") or {}
+    if frame_count > 1:
+        seen = f"You have {frame_count} frames from across this clip, in order."
+    elif frame_count == 1:
+        seen = "You have one frame, from the middle of this clip."
+    else:
+        seen = "You have no frames for this clip."
+    parts = [
+        "## The clip",
+        f"Clip {entry.get('index', '?')} of {len(segments)}, "
+        f"{float(entry.get('duration') or 0):.0f} seconds, at "
+        f"{entry.get('range') or entry.get('timestamp') or ''} of a "
+        f"{float(video.get('duration') or 0) / 60:.0f}-minute video.",
+        seen,
+        "",
+    ]
+
+    facts = _clip_facts(report, entry)
+    if facts:
+        parts += ["## What was measured here",
+                  "Context for what you are looking at. Do not repeat these — "
+                  "they are printed under your paragraph already.",
+                  *(f"- {f}" for f in facts), ""]
+
+    labels = _labels_here(entry)
+    if labels:
+        # Asked for explicitly, because the measurements section above says not
+        # to repeat what the page already prints and a model applies that to
+        # everything it is handed. A run flagged something here and the
+        # paragraph said nothing about it, which is the one omission that makes
+        # this section worth reading at all.
+        parts += ["## What was labelled here",
+                  "Weigh these against the frames and say so — rule 9. Whether "
+                  "you can see what was flagged is the question; agreeing with "
+                  "it is not the answer.",
+                  *labels, ""]
+
+    notes = _notes_here(report, entry)
+    if notes:
+        parts += ["## Notes written over this span earlier",
+                  "Each was written from a single frame of this span by "
+                  "someone who could not see the others, and not necessarily "
+                  "from the frames you have. You can see the span. Use them, "
+                  "and where they disagree with what is in front of you, go "
+                  "with the frames.",
+                  *(f"- {n}" for n in notes), ""]
+
+    if previous:
+        parts += ["## What the previous clip was",
+                  previous.strip()[:CARRY_CHARS], ""]
+
+    # Last, and given whatever budget is left. On the footage this pass exists
+    # for the section is empty and says so — which is itself worth telling the
+    # model, so it does not go looking for dialogue to account for.
+    head = "\n".join(parts)
+    spare = max(400, max_chars - len(head) - len(CLIP_TASK) - 200)
+    speech = "\n".join(_speech_here(entry))[:spare]
+    if speech:
+        parts += ["## What was said here, in order", speech, ""]
+    else:
+        parts += ["## What was said here",
+                  "Nothing was transcribed as speech in this clip, so the "
+                  "frames are all there is to go on.", ""]
+
+    parts += ["## Task", CLIP_TASK]
+    return "\n".join(parts)
+
+
+def _takes_a_list(query) -> bool:
+    """Whether this ``query`` accepts several frames or only ``frame_base64``.
+
+    Asked rather than assumed because the answer changed: ``LLMModule.query``
+    took one picture for most of its life, and an object of that vintage handed
+    ``frames=`` raises ``TypeError`` — which would cost the clip its paragraph
+    for a reason that has nothing to do with the footage.
+    """
+    import inspect
+
+    try:
+        return "frames" in inspect.signature(query).parameters
+    except (TypeError, ValueError):                # pragma: no cover - builtins
+        return False
+
+
+def _frames_delivered(llm, images: Optional[Sequence[str]]) -> int:
+    """How many of these frames this object will actually put in front of a model.
+
+    Not the same as how many were sampled, and the gap is a trap worth naming.
+    Sampling four and sending one is fine; *saying* four while sending one is
+    not, because the answer then describes motion nobody showed the model —
+    which is why this and :func:`_read_one` have to agree, and why the prompt
+    is told the number this returns rather than the number that was sampled.
+    """
+    frames = [i for i in (images or []) if i]
+    if not frames:
+        return 0
+    if hasattr(llm, "generate"):
+        return len(frames)
+    if hasattr(llm, "query"):
+        return len(frames) if _takes_a_list(llm.query) else 1
+    return 0
+
+
+def system_prompt_for(model_name: Optional[str]) -> str:
+    """The brief this model can actually receive."""
+    from modules.llm_models import is_captioner
+
+    return CAPTIONER_SYSTEM_PROMPT if is_captioner(model_name) \
+        else CLIP_SYSTEM_PROMPT
+
+
+def _read_one(llm, prompt: str, images: Sequence[str],
+              system: Optional[str] = None) -> str:
+    """One vision call, on whichever interface the object offers.
+
+    Both are handled explicitly, and anything else is an error — the same
+    reasoning as :func:`modules.moment_narration._caption_one`, and for the
+    same reason it had to be written there. Reaching for ``generate`` inside a
+    ``try`` and falling back to text on ``AttributeError`` looks like tolerance
+    of a missing feature; against an ``LLMModule`` it *always* takes the
+    fallback, and every paragraph in the run is then written from the
+    measurements with one warning line at the top of the log.
+
+    That failure is invisible in the output. A model asked to describe a clip
+    it was never shown writes a fluent, plausible paragraph out of the figures
+    it was handed, and nothing on the page distinguishes it from one written
+    from the pictures. So there is no text-only path here at all: a clip that
+    cannot be seen loses its paragraph and keeps its measurements.
+    """
+    frames = [i for i in (images or []) if i]
+    if not frames:
+        raise ValueError("no frames to read")
+    system = system or CLIP_SYSTEM_PROMPT
+    if hasattr(llm, "generate"):
+        return llm.generate(prompt, system=system,
+                            max_tokens=CLIP_TOKENS,
+                            temperature=CLIP_TEMPERATURE,
+                            images=list(frames))
+    if hasattr(llm, "query"):
+        if _takes_a_list(llm.query):
+            return llm.query(prompt, system_prompt=system,
+                             frames=list(frames), free_chat_mode=True,
+                             max_tokens=CLIP_TOKENS,
+                             temperature=CLIP_TEMPERATURE)
+        # One frame only, and the middle one: the edges of a sampled span sit
+        # closest to whatever bounded it, which for a clip is its own boundary.
+        return llm.query(prompt, system_prompt=system,
+                         frame_base64=frames[len(frames) // 2],
+                         free_chat_mode=True, max_tokens=CLIP_TOKENS,
+                         temperature=CLIP_TEMPERATURE)
+    raise TypeError(
+        f"{type(llm).__name__} offers neither generate() nor query()")
+
+
+def tell(report: Mapping,
+         *,
+         llm,
+         frames_fn: Optional[Callable] = None,
+         model_name: Optional[str] = None,
+         log_fn=print,
+         cancel_fn: Optional[Callable[[], bool]] = None) -> list:
+    """Read every kept clip. Returns the segments, ``story`` attached.
+
+    A clip whose call fails keeps its measurements and loses only its
+    paragraph, and the run continues — thirteen of fourteen is still the thing
+    the user asked for. A clip whose *frames* fail is skipped for the same
+    reason :func:`_read_one` has no text-only path: there is nothing to read.
+
+    ``model_name`` picks the brief and nothing else — see
+    :func:`modules.chapter_story.tell`.
+    """
+    from modules.chapter_story import trim_repetition
+
+    segments = [dict(e) for e in (report.get("segments") or [])]
+    if not segments or llm is None:
+        return segments
+
+    system = system_prompt_for(model_name)
+
+    previous = None
+    for position, entry in enumerate(segments, start=1):
+        if cancel_fn is not None and cancel_fn():
+            log_fn(f"⏹️ Stopped after {position - 1} of {len(segments)} clips.")
+            break
+        log_fn(f"🖼️ Reading clip {position} of {len(segments)}"
+               f" ({entry.get('range', '')})…")
+        images = None
+        if frames_fn is not None:
+            try:
+                images = frames_fn(float(entry.get("start") or 0.0),
+                                   float(entry.get("end") or 0.0))
+            except Exception as exc:
+                print(f"⚠️ Frames for clip {position} failed: {exc}")
+        seen = _frames_delivered(llm, images)
+        if not seen:
+            log_fn(f"⚠️ Clip {position} has no frames to read; skipped.")
+            continue
+        try:
+            text = (_read_one(llm,
+                              clip_prompt(report, entry, previous,
+                                          frame_count=seen),
+                              images, system) or "").strip()
+        except Exception as exc:
+            log_fn(f"⚠️ Clip {position} could not be read: {exc}")
+            continue
+        if not text:
+            continue
+        trimmed = trim_repetition(text)
+        if len(trimmed) < len(text):
+            log_fn(f"✂️ Clip {position} repeated itself; kept what came before.")
+            text = trimmed
+        entry["story"] = text
+        previous = text
+    return segments
+
+
+def tell_report_file(json_path: str,
+                     *,
+                     llm,
+                     model_name: Optional[str] = None,
+                     frames_fn: Optional[Callable] = None,
+                     log_fn=print,
+                     cancel_fn: Optional[Callable[[], bool]] = None) -> int:
+    """Read the clips of a report on disk. Returns how many were read.
+
+    Re-renders the page from the updated record rather than patching it, for the
+    same reason :func:`modules.chapter_story.tell_report_file` does: the record
+    and the page must not be able to disagree.
+
+    ``frames_fn`` is derived from the record's own video path when not supplied.
+    There is no way to ask for this pass *without* frames, because there is no
+    such pass — see :func:`_read_one`.
+    """
+    import json
+
+    from modules.chapter_story import frames_from_video
+    from modules.highlight_report import media_src_for, render_html
+
+    with open(json_path, encoding="utf-8") as fh:
+        report = json.load(fh)
+
+    if frames_fn is None:
+        source = str((report.get("video") or {}).get("path") or "")
+        frames_fn = frames_from_video(source, count=FRAMES_PER_CLIP)
+    if frames_fn is None:
+        # Refused rather than run: the whole content of these paragraphs is the
+        # frames, so a run without them would spend the model time to produce
+        # nothing the card does not already say — and would look, on the page,
+        # exactly like a run that had worked.
+        log_fn("⚠️ The source video is not where the report says it is, so "
+               "there are no frames to read. Nothing was written — this pass "
+               "has nothing to say without the pictures.")
+        return 0
+
+    segments = tell(report, llm=llm, frames_fn=frames_fn,
+                    model_name=model_name, log_fn=log_fn, cancel_fn=cancel_fn)
+    read = [e for e in segments if e.get("story")]
+    if not read:
+        return 0
+
+    # Re-read before writing, and merge rather than replace. This pass takes
+    # minutes, and the record on disk is live the whole time: the advisor's
+    # summary and the chat's answers are written into the same file from the
+    # app, by a user who is looking at the report *while* this runs. Writing
+    # back the copy loaded at the start silently reverts whatever they did in
+    # the meantime — which is not a hypothetical, it happened on the run this
+    # was written for, and it looks from the outside exactly like the pass
+    # having done nothing.
+    #
+    # Only what this pass owns is merged in: the per-clip paragraph, matched by
+    # clip index, and the stamp. Anything else in the newer record wins.
+    latest = report
+    try:
+        with open(json_path, encoding="utf-8") as fh:
+            latest = json.load(fh)
+    except Exception as exc:                       # pragma: no cover - defensive
+        print(f"⚠️ Could not re-read {json_path} ({exc}); writing what was read")
+
+    stories = {e.get("index"): e["story"] for e in read}
+    written = 0
+    for entry in (latest.get("segments") or []):
+        story = stories.get(entry.get("index"))
+        if story:
+            entry["story"] = story
+            written += 1
+    if not written:
+        # The clips on disk are not the clips that were read — a re-analysis
+        # landed while this ran. Its report is the current one and this one
+        # describes footage it no longer contains.
+        log_fn("⚠️ The report was re-analysed while the clips were being read, "
+               "so these readings describe a cut that no longer exists. "
+               "Nothing was written.")
+        return 0
+
+    latest["clip_story"] = {
+        "model": str(model_name or ""),
+        "at": _dt.datetime.now().isoformat(timespec="seconds"),
+        "clips": written,
+    }
+    report = latest
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=1)
+
+    html_path = json_path[:-5] + ".html" if json_path.endswith(".json") else None
+    if html_path and os.path.exists(html_path):
+        # Through `media_src_for`, so re-rendering does not quietly strip the
+        # per-clip players a full write put there.
+        with open(html_path, "w", encoding="utf-8") as fh:
+            fh.write(render_html(report, media_src=media_src_for(report,
+                                                                 html_path)))
+    return len(read)
+
+
+def _main(argv=None) -> int:
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(
+        prog="python -m modules.clip_story",
+        description="Describe each kept clip of a report from its own frames.")
+    parser.add_argument("report", help="the *_why.json written beside a cut")
+    parser.add_argument("--backend", default="ollama",
+                        choices=("ollama", "llama-cpp"))
+    # Was llava-llama3, which is a generation behind and fails this job rather
+    # than merely doing it worse. Measured over one 14-clip report against the
+    # same frames and prompt: it opened paragraphs "This image captures...",
+    # having processed one of the four frames it was given, which makes rule 4
+    # unanswerable by construction; it described a moment with several people
+    # as involving two, spending its length on flooring and furniture; and it
+    # took 296 s against 212 s. See docs/advisor/models.md.
+    parser.add_argument("--model", default="qwen2.5vl:7b",
+                        help="a model that can see, current-generation; "
+                             "a .gguf path for llama-cpp")
+    parser.add_argument("--mmproj", default=None,
+                        help="vision projector, for llama-cpp models that need "
+                             "one beside the weights")
+    args = parser.parse_args(argv)
+
+    from modules.advisor import load_llm
+
+    llm = load_llm(args.backend, args.model, mmproj=args.mmproj, vision=True)
+    if llm is None:
+        return 1
+    read = tell_report_file(args.report, llm=llm,
+                            model_name=f"{args.backend}/{args.model}")
+    if not read:
+        print("Nothing was read; the report is unchanged.")
+        return 1
+    with open(args.report, encoding="utf-8") as fh:
+        total = len(json.load(fh).get("segments") or [])
+    print(f"Read {read} of {total} clips.")
+    return 0
+
+
+if __name__ == "__main__":                         # pragma: no cover
+    raise SystemExit(_main())

--- a/modules/highlight_report.py
+++ b/modules/highlight_report.py
@@ -2929,6 +2929,19 @@ def media_src_for(report: Mapping, html_path: str) -> Optional[str]:
     return quote(rel.replace(os.sep, "/"))
 
 
+def _url_name(path: str) -> str:
+    """The file name out of a path written for either operating system.
+
+    ``os.path.basename`` splits on the *host's* separator. These paths arrive
+    from a report record rather than off this machine's disk, so a report
+    written on Windows and rendered anywhere else keeps the entire drive-letter
+    path as its "file name" and links at something that cannot exist. Both
+    separators are treated as one, so the link is the same wherever the page is
+    built.
+    """
+    return str(path).replace("\\", "/").rsplit("/", 1)[-1]
+
+
 def serve_url_for(serve_base: Optional[str], html_path: str) -> Optional[str]:
     """This report's own address under ``serve_base``, or nothing.
 
@@ -2941,7 +2954,7 @@ def serve_url_for(serve_base: Optional[str], html_path: str) -> Optional[str]:
     base = str(serve_base or "").strip()
     if not base:
         return None
-    return base.rstrip("/") + "/" + quote(os.path.basename(html_path))
+    return base.rstrip("/") + "/" + quote(_url_name(html_path))
 
 
 def media_url_for(media_base: Optional[str], report: Mapping) -> Optional[str]:
@@ -2957,7 +2970,7 @@ def media_url_for(media_base: Optional[str], report: Mapping) -> Optional[str]:
     source = (report.get("video") or {}).get("path")
     if not base or not source:
         return None
-    return base.rstrip("/") + "/" + quote(os.path.basename(str(source)))
+    return base.rstrip("/") + "/" + quote(_url_name(source))
 
 
 def write_report(report: Mapping, html_path: str,

--- a/modules/highlight_report.py
+++ b/modules/highlight_report.py
@@ -2487,6 +2487,49 @@ def _spoken(entry: Mapping) -> str:
             f'{_quote_lines(lines, seekable=True)}</div>')
 
 
+def _clip_story(entry: Mapping) -> str:
+    """What a model read off this clip's frames, when one was asked.
+
+    Above the measurements it was written from and inside the same card, for the
+    reason the chapter paragraph is: a reader who doubts a sentence has to find
+    the figures without leaving it. Marked at both ends — a class the stylesheet
+    sets apart, and the word "read" in the label — because a reading presented
+    as a measurement is worse than no reading at all.
+
+    It shares the chapter block's ``.story`` styling deliberately. The two are
+    the same kind of claim at two scales, and giving them two looks would imply
+    a difference in standing that does not exist.
+    """
+    text = str(entry.get("story") or "").strip()
+    if not text:
+        return ""
+    return (f'<div class="story"><span class="lab">read from this clip</span>'
+            f'<p>{html.escape(text)}</p></div>')
+
+
+def _clip_story_note(report: Mapping) -> str:
+    """Which model wrote the per-clip paragraphs, and when.
+
+    The chapter block has always said this and the clip cards never did, which
+    left the one part of a report most likely to be wrong as the one part whose
+    author could not be identified. It matters off this machine: a report
+    arriving from someone else is unreadable as evidence unless it says what
+    produced the prose, and the models differ enough that the same footage
+    reads differently depending on which one ran.
+    """
+    read = report.get("clip_story") or {}
+    if not read:
+        return ""
+    when = str(read.get("at") or "")
+    return (f'<p class="note">The paragraph inside each card was written by '
+            f'{html.escape(str(read.get("model") or "a local model"))} from '
+            f'that clip\'s own frames'
+            + (f', {html.escape(when)}' if when else '')
+            + '. Those paragraphs are a reading, not a measurement — every '
+              'figure beside them was computed before any model saw the '
+              'footage.</p>')
+
+
 def _shot(entry: Mapping, composed: frozenset) -> str:
     """The thumbnail, with what the detector saw drawn over it.
 
@@ -2539,6 +2582,21 @@ def _player_script(media_src: Optional[str]) -> str:
         "if(v){v.currentTime=parseFloat(b.dataset.t);v.play();"
         "v.scrollIntoView({block:'nearest'});}});});"
         "document.querySelectorAll('.play video').forEach(function(v){"
+        # Both halves of what `#t=start,end` promises, for the browsers that
+        # ignore it — chiefly the mobile ones, which is where a report is read
+        # away from the machine that made it. Where the fragment *was* honoured
+        # the player is already at the right second, so the guard below leaves
+        # it alone rather than seeking twice.
+        "var a=parseFloat(v.dataset.start||'0'),b=parseFloat(v.dataset.end||'0');"
+        "v.addEventListener('loadedmetadata',function(){"
+        "if(!v.dataset.cued&&a>0&&Math.abs(v.currentTime-a)>0.5){"
+        "v.dataset.cued='1';try{v.currentTime=a;}catch(e){}}});"
+        # And stopping where the clip does. Without this a browser that dropped
+        # the fragment plays on into the next scene, which is worse than
+        # starting late: the reader is then checking a claim against footage the
+        # claim was never about.
+        "v.addEventListener('timeupdate',function(){"
+        "if(b>a&&v.currentTime>b){v.pause();}});"
         "v.addEventListener('error',function(){"
         "var bar=v.closest('.play').querySelector('.playbar');"
         "if(bar&&!bar.dataset.warned){bar.dataset.warned='1';"
@@ -2590,8 +2648,19 @@ def _player(entry: Mapping, media_src: Optional[str]) -> str:
         f'<button class="seek" data-t="{float(sec):.0f}">▶ {html.escape(label)}'
         f' ({html.escape(str(stamp))})</button>'
         for label, sec, stamp in marks)
+    # `playsinline` because iOS otherwise takes the tap as a request to go
+    # fullscreen, and a player that hijacks the screen is no longer beside the
+    # figures it is there to let the reader check.
+    #
+    # The bounds are repeated as data attributes rather than left to the media
+    # fragment alone. The fragment is the better mechanism where it works — the
+    # browser fetches only the range asked for — but mobile browsers honour it
+    # inconsistently, and one that ignores it starts the clip at zero and plays
+    # to the end of the file. Duplicating the numbers costs nothing and lets the
+    # script put back both halves of what the fragment promises.
     return (f'<div class="play">'
-            f'<video controls preload="none" '
+            f'<video controls playsinline preload="none" '
+            f'data-start="{start:.2f}" data-end="{end:.2f}" '
             f'src="{html.escape(media_src)}#t={start:.0f},{end:.0f}"></video>'
             f'<div class="playbar">{jump}'
             f'<span class="dim">plays the source file in place</span></div></div>')
@@ -2640,8 +2709,58 @@ def _segment_wave(report: Mapping, entry: Mapping) -> str:
     )
 
 
+def _media_link(entry: Mapping, media_url: Optional[str]) -> str:
+    """A hand-off to whatever app on this device can open the footage.
+
+    The inline player needs HTTP: a browser cannot fetch `smb://` — no browser
+    implements the scheme — and cannot seek anything without range requests. But
+    a *link* is not a fetch. Android hands `smb://` to whichever app claimed the
+    scheme, and X-plore or VLC opens the file. So a report read from a share can
+    still reach its footage, with nothing serving it.
+
+    What cannot survive the hand-off is the position: there is no agreed way to
+    tell another app to start at 1:19:04, so the video opens at zero. Hence the
+    timestamp in the link text rather than in the URL — the reader seeks by hand,
+    which is worth saying plainly instead of letting them wonder why the clip
+    they were promised is not what started playing.
+    """
+    if not media_url:
+        return ""
+    stamp = str(entry.get("timestamp") or "").strip()
+    at = f" — seek to {html.escape(stamp)}" if stamp else ""
+    return (f'<div class="playbar"><a href="{html.escape(media_url, quote=True)}">'
+            f'▶ open the source in a player app</a>'
+            f'<span class="dim">{at}, since a hand-off cannot carry a '
+            f'position</span></div>')
+
+
+def _serve_link(serve_url):
+    """A way back to the copy of this report that can play its footage.
+
+    A report read away from its video is the normal case, not the exception: it
+    gets copied to a phone, or onto a share, and there the players are dead
+    because a browser cannot reach a sibling file from a `content://` origin and
+    cannot seek one without HTTP range requests. Every measurement on the page
+    is still true, which is precisely what makes the dead players confusing.
+
+    So the page carries the address where it *can* be played, put there when it
+    was written. One line, at the top, where somebody wondering why nothing
+    plays will find it before they conclude the report is broken.
+    """
+    if not serve_url:
+        return ""
+    url = str(serve_url).strip()
+    if not url:
+        return ""
+    return (f'<div class="sub">Footage lives elsewhere — '
+            f'<a href="{html.escape(url, quote=True)}">open this report over '
+            f'the network</a> to play the clips.</div>')
+
+
 def render_html(report: Mapping, title: Optional[str] = None,
-                media_src: Optional[str] = None) -> str:
+                media_src: Optional[str] = None,
+                serve_url: Optional[str] = None,
+                media_url: Optional[str] = None) -> str:
     """A page with inline CSS and embedded thumbnails.
 
     ``media_src`` is a URL — normally a relative path — to the source video. Pass
@@ -2650,6 +2769,10 @@ def render_html(report: Mapping, title: Optional[str] = None,
     media is deliberately never embedded: a dozen clips would add tens of
     megabytes to a file whose entire value is that it opens instantly.
     """
+    if serve_url is None:
+        serve_url = report.get("serve_url")
+    if media_url is None:
+        media_url = report.get("media_url")
     video = report["video"]
     totals = report["totals"]
     heading = title or f"Why these moments — {video['name']}"
@@ -2668,6 +2791,7 @@ def render_html(report: Mapping, title: Optional[str] = None,
     for e in report["segments"]:
         thumb = _shot(e, composed)
         tags = _tag_rows(e)
+        story = _clip_story(e)
         # The clip's own expression reading now sits under the Face expression
         # heading with the rest of that signal, rather than adrift at the foot
         # of the card where it read as an afterthought.
@@ -2691,11 +2815,13 @@ def render_html(report: Mapping, title: Optional[str] = None,
             f'<div class="meta">peak at {html.escape(e["timestamp"])} · '
             f'{e["duration"]:.0f}s long{from_chapter}</div>'
             f'{_bars(e, max_points)}'
+            f'{story}'
             f'{_measurements(e, peer_scores, readings, video_valence)}'
             f'{tags}'
             f'{_spoken(e)}'
             f'{_segment_wave(report, e)}'
             f'{_player(e, media_src)}'
+            f'{_media_link(e, media_url)}'
             f'{boost}</div></div>'
         )
 
@@ -2736,6 +2862,7 @@ def render_html(report: Mapping, title: Optional[str] = None,
 <body>{_section_nav()}<div class="wrap">
 <h1>{html.escape(heading)}</h1>
 <div class="sub">Generated {html.escape(report["generated_at"])}</div>
+{_serve_link(serve_url)}
 <div class="sub2">{html.escape(_run_sentence(report))}</div>
 <div class="totals">
   <div><span class="n">{totals["segments"]}</span><span class="l">segments kept</span></div>
@@ -2768,7 +2895,8 @@ def render_html(report: Mapping, title: Optional[str] = None,
         'was detected there, grouped by what produced them — <b>objects</b> '
         'come straight from the detector, <b>events</b> are combinations the '
         'composition rules recognised, <b>actions</b> come from the action '
-        'model with their confidence.</p>' + "".join(segs),
+        'model with their confidence.</p>'
+        + _clip_story_note(report) + "".join(segs),
         near, settings)}
 {_group("In closing",
         "What the run observed, what was only asserted, and what it could not "
@@ -2801,10 +2929,43 @@ def media_src_for(report: Mapping, html_path: str) -> Optional[str]:
     return quote(rel.replace(os.sep, "/"))
 
 
+def serve_url_for(serve_base: Optional[str], html_path: str) -> Optional[str]:
+    """This report's own address under ``serve_base``, or nothing.
+
+    The base names where the folder is served from -- ``http://192.168.0.10:8000/``
+    -- and the report is at its own filename beneath it. Built here rather than
+    left to the reader because the whole point is landing on *this* report; a
+    bare base drops them on a directory listing holding a filename nobody wants
+    to read off a phone screen.
+    """
+    base = str(serve_base or "").strip()
+    if not base:
+        return None
+    return base.rstrip("/") + "/" + quote(os.path.basename(html_path))
+
+
+def media_url_for(media_base: Optional[str], report: Mapping) -> Optional[str]:
+    """The source video's address under ``media_base``, or nothing.
+
+    The base names where the *folder* is reachable —
+    ``smb://192.168.0.10/movies/`` — and the video keeps the name it has on
+    disk. Deliberately not scheme-aware: `smb://` is the case this was built
+    for, but nothing here knows or cares, so an `nfs://` or a `ftp://` share
+    works the same way without this function learning about it.
+    """
+    base = str(media_base or "").strip()
+    source = (report.get("video") or {}).get("path")
+    if not base or not source:
+        return None
+    return base.rstrip("/") + "/" + quote(os.path.basename(str(source)))
+
+
 def write_report(report: Mapping, html_path: str,
                  json_path: Optional[str] = None,
                  title: Optional[str] = None,
-                 link_media: bool = True) -> None:
+                 link_media: bool = True,
+                 serve_base: Optional[str] = None,
+                 media_base: Optional[str] = None) -> None:
     """Write the page, and the record it was rendered from.
 
     The JSON is not a debugging leftover: it is the structured form a later
@@ -2815,8 +2976,19 @@ def write_report(report: Mapping, html_path: str,
     off for a page that has to survive being moved away from the footage.
     """
     src = media_src_for(report, html_path) if link_media else None
+    url = serve_url_for(serve_base, html_path)
+    media = media_url_for(media_base, report)
+    # Into the record, so the JSON carries them and every later re-render finds
+    # them. Only when one was given: writing a null would make a report that had
+    # never been served look like one whose address had been cleared.
+    if isinstance(report, dict):
+        if url:
+            report["serve_url"] = url
+        if media:
+            report["media_url"] = media
     with open(html_path, "w", encoding="utf-8") as fh:
-        fh.write(render_html(report, title=title, media_src=src))
+        fh.write(render_html(report, title=title, media_src=src,
+                             serve_url=url, media_url=media))
     if json_path:
         with open(json_path, "w", encoding="utf-8") as fh:
             json.dump(report, fh, indent=1)

--- a/modules/llm_models.py
+++ b/modules/llm_models.py
@@ -26,6 +26,29 @@ from typing import Mapping, Optional, Sequence
 # a menu only moves the failure to the point where the user has waited for it.
 BACKENDS = ("ollama", "llama-cpp")
 
+# Models that caption a picture rather than follow an instruction. The
+# distinction is not a nicety: handed a numbered rulebook, a captioner
+# reproduces it as its answer instead of obeying it — JoyCaption echoed
+# "1. WATCH THE FACE AND HANDS, NOTHING ELSE." back verbatim on every frame.
+# Every narration pass needs the same fork, so which models need it is recorded
+# once, here, beside everything else that is known about a model.
+#
+# Matched as substrings rather than exact names because the name that arrives
+# carries a tag or a vendor prefix (`joycaption:q4`, `ollama/joycaption`) and an
+# exact set would silently miss every real one.
+CAPTIONER_MODELS = ("joycaption", "joy-caption", "joy_caption")
+
+
+def is_captioner(model_name: Optional[str]) -> bool:
+    """Whether `model_name` names a captioner, and so needs a flat prompt.
+
+    Unknown names are treated as instruction-followers: that is what the prompts
+    were written for, so an unrecognised model gets the behaviour this code has
+    always had rather than a quietly different one.
+    """
+    name = (model_name or "").lower()
+    return any(tag in name for tag in CAPTIONER_MODELS)
+
 
 def _clean(entry: Mapping) -> Optional[dict]:
     """One stored entry, or ``None`` when it cannot be used."""

--- a/modules/story_run.py
+++ b/modules/story_run.py
@@ -1,0 +1,139 @@
+"""Run the narration passes over a finished report, in one call.
+
+The chapter walk and the clip read already know how to narrate a report on
+disk. What they lacked was somewhere to be called from that is not a menu: both
+were reachable only from the AI-summary button, which meant the answer to "what
+is in this video" existed only if the user knew to ask for it after the run had
+already finished, and then waited through a second pass with the window frozen.
+
+So this module is the joining piece — build the model once, run whichever
+passes are turned on, report progress, stop when the run stops. It carries no
+Qt and no pipeline state, which is what lets the pipeline call it mid-run and
+the window call it from a menu without either growing a copy of the other's
+logic.
+
+Both passes are cheap to *decide* and expensive to *run*, so the decision is
+made here and stated in the log before the first call: several minutes of
+apparent silence is the failure mode this pass has, and the fix is saying what
+is about to happen rather than making it faster.
+
+Why the model is built once for both: each pass loading its own would hold two
+copies of a vision model in memory at the same moment on a machine that usually
+cannot spare one.
+"""
+from __future__ import annotations
+
+from typing import Callable, Mapping, Optional
+
+# What a run does when nothing says otherwise: both, at both scales. They answer
+# different questions and neither substitutes for the other — a clip paragraph
+# says what is in these few seconds, a chapter paragraph says what the stretch
+# they sit in was doing — so a report with one and not the other can always be
+# asked something it cannot answer.
+#
+# The cost is the honest objection and it is real: this is a model call per
+# chapter *plus* one per clip, and on a local model that is the slowest thing
+# the report does by a wide margin. It is defaulted on anyway because a run the
+# user has already committed minutes to is the cheapest possible moment to spend
+# them, and the alternative — discovering afterwards that the question needs a
+# second pass over footage now finished — costs the whole wait again. Both
+# checkboxes turn it off for a run that does not want it.
+DEFAULTS = {"narrate_clips": True, "narrate_chapters": True}
+
+
+def _entry(config: Mapping) -> dict:
+    """The model to narrate with, as the GUI stored it."""
+    entry = config.get("narration_model") or {}
+    if not isinstance(entry, Mapping):
+        return {}
+    return dict(entry)
+
+
+def wanted(config: Mapping) -> tuple:
+    """Which passes this run should make: ``(chapters, clips)``."""
+    return (bool(config.get("narrate_chapters", DEFAULTS["narrate_chapters"])),
+            bool(config.get("narrate_clips", DEFAULTS["narrate_clips"])))
+
+
+def narrate_report_file(json_path: str,
+                        *,
+                        config: Mapping,
+                        log_fn: Callable[[str], None] = print,
+                        cancel_fn: Optional[Callable[[], bool]] = None) -> dict:
+    """Run the wanted passes over the report at ``json_path``.
+
+    Returns ``{"chapters": n, "clips": n}`` — how many of each were written.
+    Never raises: this runs at the tail of a pipeline that has already produced
+    the cut and the report, and a narration that cannot be written is not a
+    reason to lose either. Every failure becomes a log line and a zero.
+    """
+    from modules import advisor
+    from modules.llm_models import label_for
+
+    done = {"chapters": 0, "clips": 0}
+    do_chapters, do_clips = wanted(config)
+    if not (do_chapters or do_clips):
+        return done
+    if cancel_fn is not None and cancel_fn():
+        return done
+
+    entry = _entry(config)
+    backend = entry.get("backend") or "ollama"
+    name = entry.get("model") or "llama3"
+    label = label_for(entry) if entry else f"{backend}/{name}"
+
+    try:
+        llm = advisor.load_llm(backend, name, mmproj=entry.get("mmproj"),
+                               vision=True)
+    except Exception as exc:
+        log_fn(f"⚠️ Narration skipped — {label} could not be loaded: {exc}")
+        return done
+    if llm is None:
+        log_fn(f"⚠️ Narration skipped — could not reach {label}. The report "
+               "keeps its measurements; only the telling needs a model.")
+        return done
+
+    # Asked once, before either pass, because the clip pass is meaningless
+    # without it and the chapter pass is merely poorer — see the two passes'
+    # own notes. Said as a warning rather than an abort for the chapter walk.
+    sees = not hasattr(llm, "accepts_images") or llm.accepts_images()
+    if do_clips and not sees:
+        log_fn(f"⚠️ {label} has no vision half loaded, so it cannot see the "
+               "frames — and the frames are the whole point of the clip pass. "
+               "Skipping it.")
+        do_clips = False
+
+    if do_chapters:
+        done["chapters"] = _pass(
+            "chapters", json_path, llm=llm, label=label,
+            log_fn=log_fn, cancel_fn=cancel_fn)
+    if do_clips and not (cancel_fn is not None and cancel_fn()):
+        done["clips"] = _pass(
+            "clips", json_path, llm=llm, label=label,
+            log_fn=log_fn, cancel_fn=cancel_fn)
+    return done
+
+
+def _pass(which: str, json_path: str, *, llm, label, log_fn, cancel_fn) -> int:
+    """One pass, with its failure contained. Returns how many it wrote.
+
+    The two passes are called through one function because the only differences
+    between the call sites are the module and the noun, and a second copy of the
+    try/except would be a second place for the contract above ("never raises")
+    to stop being true.
+    """
+    if which == "chapters":
+        from modules.chapter_story import tell_report_file
+        noun = "chapter"
+    else:
+        from modules.clip_story import tell_report_file
+        noun = "clip"
+
+    log_fn(f"📖 Narrating {noun}s with {label} — one call each, so this takes "
+           "minutes rather than seconds.")
+    try:
+        return tell_report_file(json_path, llm=llm, model_name=label,
+                                log_fn=log_fn, cancel_fn=cancel_fn) or 0
+    except Exception as exc:
+        log_fn(f"⚠️ The {noun} narration failed: {exc}")
+        return 0

--- a/pipeline.py
+++ b/pipeline.py
@@ -2312,12 +2312,34 @@ def run_highlighter(video_path, sample_rate=5, gui_config: dict = None,
                 base = os.path.splitext(OUTPUT_FILE)[0] if OUTPUT_FILE else \
                     os.path.splitext(video_path)[0]
                 html_path = f"{base}_why.html"
-                write_report(report, html_path, json_path=f"{base}_why.json")
+                write_report(report, html_path, json_path=f"{base}_why.json",
+                             serve_base=gui_config.get("report_serve_base"),
+                             media_base=gui_config.get("report_media_base"))
                 log(f"📄 Why-these-moments report: {os.path.basename(html_path)}")
                 # The same breakdown into the debug log, from the same dict, so
                 # the two can never disagree about what happened.
                 from modules.highlight_report import render_text
                 print("\n" + render_text(report))
+
+                # Narrate what was just written, if the run asked for it. Here
+                # rather than on the button it used to live behind: this is a
+                # worker thread, so the several minutes it costs are minutes the
+                # window stays alive and cancellable, where the menu path ran it
+                # on the GUI thread and froze everything until it finished.
+                #
+                # After `write_report` and reading the file back, not before and
+                # not from `report`, because both passes re-render the page from
+                # the record they update — the page and the JSON must not be
+                # able to disagree about what the model said.
+                try:
+                    from modules.story_run import narrate_report_file
+
+                    narrate_report_file(
+                        f"{base}_why.json", config=gui_config, log_fn=log,
+                        cancel_fn=(lambda: bool(cancel_flag
+                                                and cancel_flag.is_set())))
+                except Exception as _ne:
+                    log(f"⚠️ Narration skipped: {_ne}")
             except Exception as _re:
                 log(f"⚠️ Highlight report skipped: {_re}")
 

--- a/tests/test_clip_story.py
+++ b/tests/test_clip_story.py
@@ -1,0 +1,505 @@
+"""Tests for the per-clip reading — the boundary, not the prose.
+
+Nothing here can check whether a paragraph is any good; a model wrote it. What
+can be checked is everything around it, and it is the same list the chapter
+pass keeps, plus the one thing this pass exists for:
+
+* a clip is read from *its own* frames and its own material, so a paragraph
+  cannot describe a span it was never shown;
+* the frames are sampled across the clip, not at the peak second, because the
+  answer is supposed to be about what changes;
+* one failed or empty call costs one paragraph and not the run;
+* what a model wrote is stored and rendered as a reading, with the model named,
+  and never merged into the measured sentences beside it;
+* a report with no transcript still produces a full prompt — that is the case
+  the pass was written for, and the one where an empty section silently
+  becomes an empty answer.
+
+Fixture speech is mundane on purpose — a workshop, a kitchen. The reading path
+does not care what was said, and the repo carries no content.
+"""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from modules import clip_story
+from modules.highlight_report import build_report, render_html
+
+
+FRAMES = ["Zg==", "cg==", "YQ==", "bQ=="]
+
+
+def _frames(_start, _end):
+    return list(FRAMES)
+
+
+class _FakeLLM:
+    """A raw backend — exposes generate(), which takes a list of frames."""
+
+    def __init__(self, reply="Two people at a bench.", boom=False,
+                 empty_after=None):
+        self.reply, self.boom = reply, boom
+        self.empty_after = empty_after
+        self.calls = []
+
+    def generate(self, prompt, system="", max_tokens=1024, images=None, **kw):
+        self.calls.append({"prompt": prompt, "system": system,
+                           "images": images, "kw": kw})
+        if self.boom:
+            raise RuntimeError("model not loaded")
+        if self.empty_after is not None and len(self.calls) > self.empty_after:
+            return "  "
+        return f"{self.reply} ({len(self.calls)})"
+
+
+class _FakeModule:
+    """What the GUI actually holds — `LLMModule`, which offers query() only.
+
+    The distinction is the whole of `_frames_delivered` and half of
+    `_read_one`: an object of this shape is why the chapter pass has never sent
+    a picture from the app, and a fake that exposes generate() would prove
+    nothing about the path the app takes.
+    """
+
+    def __init__(self, reply="Read across the clip."):
+        self.reply = reply
+        self.calls = []
+
+    def query(self, prompt, system_prompt="", frame_base64=None, frames=None,
+              **kw):
+        self.calls.append({"prompt": prompt, "system": system_prompt,
+                           "frame": frame_base64, "frames": frames, "kw": kw})
+        return f"{self.reply} ({len(self.calls)})"
+
+
+class _OldModule:
+    """An `LLMModule` from before query() learned to take several frames.
+
+    Handing this one ``frames=`` raises TypeError, which `tell` would catch and
+    turn into a lost paragraph — a clip losing its reading because of a keyword
+    argument rather than because of anything in the footage.
+    """
+
+    def __init__(self, reply="One frame's worth."):
+        self.reply = reply
+        self.calls = []
+
+    def query(self, prompt, system_prompt="", frame_base64=None, **kw):
+        self.calls.append({"prompt": prompt, "system": system_prompt,
+                           "frame": frame_base64, "kw": kw})
+        return f"{self.reply} ({len(self.calls)})"
+
+
+def _transcript():
+    out = []
+    for t in range(100, 130, 10):
+        out.append({"start": float(t), "end": float(t) + 4.0,
+                    "text": "pass me the chisel and the mallet"})
+    for t in range(300, 330, 10):
+        out.append({"start": float(t), "end": float(t) + 4.0,
+                    "text": "the kettle is next to the mugs"})
+    return out
+
+
+def _report(transcript=None):
+    score = np.zeros(600)
+    score[110] = 10.0
+    score[310] = 12.0
+    return build_report(
+        video_path="a.mp4", video_duration=600, score=score,
+        signals={"object": score}, segments=[(100, 130), (300, 330)],
+        transcript=transcript)
+
+
+class TestPrompt:
+    def test_a_clip_is_read_from_its_own_speech(self):
+        rep = _report(_transcript())
+        prompt = clip_story.clip_prompt(rep, rep["segments"][0])
+        assert "chisel" in prompt
+        # The other clip's words must not be in this one's prompt, or a
+        # paragraph can describe a span it was never shown.
+        assert "kettle" not in prompt
+
+    def test_the_measured_sentences_are_included(self):
+        rep = _report()
+        prompt = clip_story.clip_prompt(rep, rep["segments"][0])
+        assert "What was measured here" in prompt
+
+    def test_a_silent_clip_says_so_rather_than_omitting_the_section(self):
+        # The whole reason this pass exists. A report with no transcript must
+        # still tell the model there is nothing to account for, or it goes
+        # looking for dialogue in the frames.
+        rep = _report()
+        prompt = clip_story.clip_prompt(rep, rep["segments"][0])
+        assert "Nothing was transcribed as speech" in prompt
+        assert "frames are all there is to go on" in prompt
+
+    def test_the_previous_clip_is_carried_forward_but_capped(self):
+        rep = _report()
+        prompt = clip_story.clip_prompt(rep, rep["segments"][1],
+                                        previous="X" * 5000)
+        assert "What the previous clip was" in prompt
+        assert "X" * (clip_story.CARRY_CHARS + 1) not in prompt
+
+    def test_detector_labels_are_named_by_the_source_that_produced_them(self):
+        rep = _report()
+        entry = dict(rep["segments"][0])
+        entry["objects"] = ["bench"]
+        entry["events"] = ["bench_work"]
+        entry["actions"] = [{"name": "sanding", "confidence": 0.02,
+                             "tier": "reduced"}]
+        prompt = clip_story.clip_prompt(rep, entry)
+        assert "object detector labelled" in prompt
+        assert "composition rules recognised" in prompt
+        # The confidence travels with the action, so a 0.02 guess is not read
+        # as an observation of equal standing to the detections above it.
+        assert "0.02" in prompt
+
+    def test_the_task_asks_what_the_clip_shows(self):
+        rep = _report()
+        assert clip_story.CLIP_TASK in clip_story.clip_prompt(
+            rep, rep["segments"][0])
+
+    def test_the_prompt_says_how_many_frames_the_model_actually_has(self):
+        # Rule 4 asks what changes between the frames. Told it has four when it
+        # was sent one, a model answers the question it was asked rather than
+        # the one it can see — and invents the motion to do it.
+        rep = _report()
+        many = clip_story.clip_prompt(rep, rep["segments"][0], frame_count=4)
+        one = clip_story.clip_prompt(rep, rep["segments"][0], frame_count=1)
+        assert "4 frames from across this clip" in many
+        assert "one frame, from the middle" in one
+
+
+class TestNarrationNotes:
+    """A narration already run over this video is free material, and only the
+    notes landing inside the clip may be used.
+
+    Skipped where per-frame narration does not exist: this file is shared
+    verbatim between the two editions, and a test that cannot pass in one of
+    them is worth less than one identical file that skips honestly there.
+    """
+
+    def test_notes_inside_the_clip_are_offered_and_others_are_not(self, tmp_path,
+                                                                  monkeypatch):
+        narration_notes = pytest.importorskip("modules.narration_notes")
+
+        video = tmp_path / "a.mp4"
+        video.write_bytes(b"")
+        narration_notes.save(str(video), [
+            {"start": 105.0, "end": 115.0, "text": "she reaches for the chisel"},
+            {"start": 305.0, "end": 315.0, "text": "he fills the kettle"},
+        ], log_fn=lambda _m: None)
+
+        rep = _report()
+        rep["video"]["path"] = str(video)
+        prompt = clip_story.clip_prompt(rep, rep["segments"][0])
+        assert "reaches for the chisel" in prompt
+        assert "kettle" not in prompt
+
+    def test_no_sidecar_means_no_section(self):
+        rep = _report()
+        assert "Notes written over this span" not in clip_story.clip_prompt(
+            rep, rep["segments"][0])
+
+
+class TestInterface:
+    """Which call is made, and how many frames survive it.
+
+    `LLMModule` — the object the GUI holds — offers `query`, not `generate`.
+    The chapter pass reaches for `generate` inside a try/except and falls back
+    to text on the AttributeError, so from the app it has never once sent a
+    picture. Everything here exists so that cannot happen again quietly.
+    """
+
+    def test_a_raw_backend_is_sent_every_frame(self):
+        rep = _report()
+        llm = _FakeLLM()
+        clip_story.tell(rep, llm=llm, log_fn=lambda _m: None, frames_fn=_frames)
+        assert llm.calls[0]["images"] == FRAMES
+
+    def test_an_llmmodule_is_sent_every_frame_through_query(self):
+        rep = _report()
+        llm = _FakeModule()
+        read = clip_story.tell(rep, llm=llm, log_fn=lambda _m: None,
+                               frames_fn=_frames)
+        assert llm.calls[0]["frames"] == FRAMES
+        assert "4 frames from across this clip" in llm.calls[0]["prompt"]
+        assert all(e["story"] for e in read)
+
+    def test_a_query_that_takes_one_frame_gets_the_middle_one(self):
+        rep = _report()
+        llm = _OldModule()
+        read = clip_story.tell(rep, llm=llm, log_fn=lambda _m: None,
+                               frames_fn=_frames)
+        assert llm.calls[0]["frame"] == FRAMES[len(FRAMES) // 2]
+        assert all(e["story"] for e in read)
+
+    def test_a_one_frame_interface_is_told_it_has_one_frame_not_four(self):
+        # Rule 4 asks what changes between the frames. A model sent one picture
+        # and told it has four answers anyway, and invents the motion to do it.
+        rep = _report()
+        llm = _OldModule()
+        clip_story.tell(rep, llm=llm, log_fn=lambda _m: None, frames_fn=_frames)
+        assert "one frame, from the middle" in llm.calls[0]["prompt"]
+        assert "4 frames" not in llm.calls[0]["prompt"]
+
+    def test_an_object_offering_neither_interface_is_an_error_not_a_paragraph(self):
+        rep = _report()
+        logged = []
+        read = clip_story.tell(rep, llm=object(), log_fn=logged.append,
+                               frames_fn=_frames)
+        assert not any(e.get("story") for e in read)
+
+    def test_without_frames_nothing_is_written_at_all(self):
+        # The paragraph's entire content is the picture. A text-only fallback
+        # would produce a fluent restatement of the figures, indistinguishable
+        # on the page from a paragraph written by a model that could see.
+        rep = _report()
+        llm = _FakeLLM()
+        logged = []
+        read = clip_story.tell(rep, llm=llm, log_fn=logged.append)
+        assert llm.calls == []
+        assert not any(e.get("story") for e in read)
+        assert any("no frames to read" in m for m in logged)
+
+
+class TestTell:
+    def test_every_clip_gets_a_paragraph(self):
+        rep = _report()
+        read = clip_story.tell(rep, llm=_FakeLLM(), log_fn=lambda _m: None,
+                               frames_fn=_frames)
+        assert all(e["story"] for e in read)
+
+    def test_clips_are_read_in_order_and_handed_the_previous_one(self):
+        rep = _report()
+        llm = _FakeLLM()
+        clip_story.tell(rep, llm=llm, log_fn=lambda _m: None, frames_fn=_frames)
+        assert len(llm.calls) == 2
+        assert "What the previous clip was" not in llm.calls[0]["prompt"]
+        assert "(1)" in llm.calls[1]["prompt"]
+
+    def test_frames_are_sampled_across_the_clip_not_at_its_peak(self):
+        # The thumbnail on the card is already the peak second. Sampling the
+        # same instant again would make the paragraph a caption of a picture
+        # the reader can see, instead of an account of what changes.
+        rep = _report()
+        spans = []
+
+        def frames(start, end):
+            spans.append((start, end))
+            return list(FRAMES)
+
+        clip_story.tell(rep, llm=_FakeLLM(), log_fn=lambda _m: None,
+                        frames_fn=frames)
+        assert spans == [(100.0, 130.0), (300.0, 330.0)]
+
+    def test_a_failing_call_costs_one_paragraph_not_the_run(self):
+        rep = _report()
+
+        class _FlakyLLM(_FakeLLM):
+            def generate(self, prompt, system="", max_tokens=1024,
+                         images=None, **kw):
+                self.calls.append({"prompt": prompt})
+                if len(self.calls) == 1:
+                    raise RuntimeError("out of memory")
+                return "The second one worked."
+
+        read = clip_story.tell(rep, llm=_FlakyLLM(), log_fn=lambda _m: None,
+                               frames_fn=_frames)
+        assert "story" not in read[0]
+        assert read[1]["story"] == "The second one worked."
+
+    def test_a_clip_whose_frames_fail_is_skipped_not_written_blind(self):
+        rep = _report()
+        llm = _FakeLLM()
+
+        def frames(start, _end):
+            return [] if start == 100.0 else list(FRAMES)
+
+        read = clip_story.tell(rep, llm=llm, log_fn=lambda _m: None,
+                               frames_fn=frames)
+        assert "story" not in read[0]
+        assert read[1]["story"]
+        assert len(llm.calls) == 1
+
+    def test_a_skipped_clip_is_not_passed_off_as_the_predecessor(self):
+        rep = _report()
+        llm = _FakeLLM(empty_after=0)
+        read = clip_story.tell(rep, llm=llm, log_fn=lambda _m: None,
+                               frames_fn=_frames)
+        assert not any(e.get("story") for e in read)
+        assert "What the previous clip was" not in llm.calls[1]["prompt"]
+
+    def test_a_looping_clip_keeps_what_came_before_the_loop(self):
+        rep = _report()
+        sentence = "They stand at the bench and say very little to each other. "
+
+        class _StuckLLM(_FakeLLM):
+            def generate(self, prompt, **kw):
+                self.calls.append({"prompt": prompt})
+                return sentence * 5
+
+        logged = []
+        read = clip_story.tell(rep, llm=_StuckLLM(), log_fn=logged.append,
+                               frames_fn=_frames)
+        assert read[0]["story"] == sentence.strip()
+        assert any("repeated itself" in m for m in logged)
+
+    def test_no_model_means_the_clips_come_back_untouched(self):
+        rep = _report()
+        assert clip_story.tell(rep, llm=None, log_fn=lambda _m: None,
+                               frames_fn=_frames) == rep["segments"]
+
+    def test_input_segments_are_not_mutated(self):
+        rep = _report()
+        clip_story.tell(rep, llm=_FakeLLM(), log_fn=lambda _m: None,
+                        frames_fn=_frames)
+        assert "story" not in rep["segments"][0]
+
+    def test_cancelling_stops_the_walk(self):
+        rep = _report()
+        llm = _FakeLLM()
+        clip_story.tell(rep, llm=llm, log_fn=lambda _m: None,
+                        frames_fn=_frames, cancel_fn=lambda: True)
+        assert llm.calls == []
+
+    def test_the_system_prompt_forbids_inventing_figures(self):
+        rep = _report()
+        llm = _FakeLLM()
+        clip_story.tell(rep, llm=llm, log_fn=lambda _m: None, frames_fn=_frames)
+        assert "Never state a number" in llm.calls[0]["system"]
+
+
+class TestRender:
+    def test_a_read_clip_is_marked_as_a_reading_on_the_page(self):
+        rep = _report()
+        rep["segments"][0]["story"] = "Two people stand at a bench."
+        page = render_html(rep)
+        assert "read from this clip" in page
+        assert "Two people stand at a bench." in page
+
+    def test_an_unread_report_gains_no_block(self):
+        assert "read from this clip" not in render_html(_report())
+
+    def test_the_reading_is_escaped_like_everything_else(self):
+        rep = _report()
+        rep["segments"][0]["story"] = "<script>alert(1)</script>"
+        assert "<script>alert(1)</script>" not in render_html(rep)
+
+
+class TestReportFile:
+    def _write(self, tmp_path):
+        from modules.highlight_report import write_report
+
+        html_path, json_path = tmp_path / "r.html", tmp_path / "r.json"
+        write_report(_report(), str(html_path), str(json_path))
+        return html_path, json_path
+
+    def test_the_record_and_the_page_are_both_updated(self, tmp_path):
+        html_path, json_path = self._write(tmp_path)
+        read = clip_story.tell_report_file(
+            str(json_path), llm=_FakeLLM(), model_name="ollama/vision",
+            frames_fn=_frames, log_fn=lambda _m: None)
+        assert read == 2
+        record = json.loads(json_path.read_text(encoding="utf-8"))
+        assert all(e["story"] for e in record["segments"])
+        # Re-rendered from the updated record rather than patched, so the two
+        # cannot disagree about what a clip says.
+        assert "read from this clip" in html_path.read_text(encoding="utf-8")
+
+    def test_the_model_is_named_in_the_record(self, tmp_path):
+        _html, json_path = self._write(tmp_path)
+        clip_story.tell_report_file(
+            str(json_path), llm=_FakeLLM(), model_name="ollama/vision",
+            frames_fn=_frames, log_fn=lambda _m: None)
+        stamp = json.loads(json_path.read_text(encoding="utf-8"))["clip_story"]
+        assert stamp["model"] == "ollama/vision"
+        assert stamp["clips"] == 2
+
+    def test_a_run_that_reads_nothing_leaves_the_report_alone(self, tmp_path):
+        _html, json_path = self._write(tmp_path)
+        before = json_path.read_text(encoding="utf-8")
+        read = clip_story.tell_report_file(
+            str(json_path), llm=_FakeLLM(empty_after=0), frames_fn=_frames,
+            log_fn=lambda _m: None)
+        assert read == 0
+        assert json_path.read_text(encoding="utf-8") == before
+
+    def test_an_edit_made_while_the_pass_ran_survives_it(self, tmp_path):
+        # The pass takes minutes and the record is live throughout — the app
+        # writes the advisor's summary into the same file while a user waits.
+        # Writing back the copy loaded at the start reverts their work, and
+        # from the outside that looks exactly like the pass having done
+        # nothing at all.
+        _html, json_path = self._write(tmp_path)
+
+        class _EditsTheFileMidRun(_FakeLLM):
+            def generate(self, prompt, **kw):
+                record = json.loads(json_path.read_text(encoding="utf-8"))
+                record["advice_narration"] = "written while the pass ran"
+                json_path.write_text(json.dumps(record), encoding="utf-8")
+                return super().generate(prompt, **kw)
+
+        clip_story.tell_report_file(
+            str(json_path), llm=_EditsTheFileMidRun(), frames_fn=_frames,
+            log_fn=lambda _m: None)
+        record = json.loads(json_path.read_text(encoding="utf-8"))
+        assert record["advice_narration"] == "written while the pass ran"
+        assert all(e["story"] for e in record["segments"])
+
+    def test_a_re_analysis_mid_run_is_refused_rather_than_merged(self, tmp_path):
+        # Different clips on disk than the ones that were read: the readings
+        # describe a cut the report no longer contains, so they are dropped
+        # rather than pinned onto whatever now sits at those indices.
+        _html, json_path = self._write(tmp_path)
+
+        class _ReAnalyses(_FakeLLM):
+            def generate(self, prompt, **kw):
+                record = json.loads(json_path.read_text(encoding="utf-8"))
+                for i, entry in enumerate(record["segments"], start=100):
+                    entry["index"] = i
+                json_path.write_text(json.dumps(record), encoding="utf-8")
+                return super().generate(prompt, **kw)
+
+        logged = []
+        read = clip_story.tell_report_file(
+            str(json_path), llm=_ReAnalyses(), frames_fn=_frames,
+            log_fn=logged.append)
+        assert read == 0
+        assert any("re-analysed" in m for m in logged)
+        record = json.loads(json_path.read_text(encoding="utf-8"))
+        assert not any(e.get("story") for e in record["segments"])
+
+    def test_a_missing_video_refuses_rather_than_writing_from_figures(self,
+                                                                     tmp_path):
+        # `_report()` names "a.mp4", which is not beside the record. The pass
+        # must decline: a page full of paragraphs written without the frames
+        # looks exactly like a page full of paragraphs written with them.
+        _html, json_path = self._write(tmp_path)
+        llm = _FakeLLM()
+        logged = []
+        read = clip_story.tell_report_file(str(json_path), llm=llm,
+                                           log_fn=logged.append)
+        assert read == 0
+        assert llm.calls == []
+        assert any("no frames to read" in m for m in logged)
+
+    def test_the_players_survive_a_re_render(self, tmp_path):
+        # Re-rendering without a media source would silently strip the per-clip
+        # players a full write put on the page.
+        from modules.highlight_report import write_report
+
+        video = tmp_path / "a.mp4"
+        video.write_bytes(b"")
+        rep = _report()
+        rep["video"]["path"] = str(video)
+        html_path, json_path = tmp_path / "r.html", tmp_path / "r.json"
+        write_report(rep, str(html_path), str(json_path))
+        assert "<video" in html_path.read_text(encoding="utf-8")
+        clip_story.tell_report_file(str(json_path), llm=_FakeLLM(),
+                                    frames_fn=_frames, log_fn=lambda _m: None)
+        assert "<video" in html_path.read_text(encoding="utf-8")

--- a/tests/test_highlight_report.py
+++ b/tests/test_highlight_report.py
@@ -1068,6 +1068,25 @@ def test_each_clip_gets_a_player_seeked_to_its_own_range():
     assert 'preload="none"' in page
 
 
+def test_a_player_works_where_the_media_fragment_is_ignored():
+    """The bounds survive a browser that drops `#t=`, which is most mobile ones.
+
+    A report is read away from the machine that wrote it more often than on it,
+    so the fragment cannot be the only thing carrying the clip's start and end.
+    `playsinline` belongs to the same problem: a player that seizes the screen
+    on tap is no longer beside the figures it exists to let a reader check.
+    """
+    from modules.highlight_report import media_src_for
+    rep = _player_report()
+    page = render_html(rep, media_src=media_src_for(rep, os.path.join(MEDIA_DIR, "o.html")))
+    assert page.count("playsinline") == 2
+    assert re.findall(r'data-start="([0-9.]+)"', page) == ["10.00", "40.00"]
+    assert re.findall(r'data-end="([0-9.]+)"', page) == ["20.00", "50.00"]
+    # Both halves, or the fallback only fixes where the clip starts and lets it
+    # run on into footage the claim beside it was never about.
+    assert "loadedmetadata" in page and "timeupdate" in page
+
+
 def test_the_seek_button_targets_the_loudest_second():
     from modules.highlight_report import media_src_for
     rep = _player_report()
@@ -1397,3 +1416,118 @@ class TestConversation:
 
     def test_a_report_nobody_asked_anything_shows_no_thread(self):
         assert "Asked of this report" not in render_html(_player_report())
+
+
+class TestServeLink:
+    """Where to go when the players are dead.
+
+    A report is read away from its footage more often than beside it, and there
+    the page is fully true and fully unplayable at once — which reads as broken
+    rather than as displaced. The link is the difference.
+    """
+
+    def test_no_link_when_nothing_says_where_it_is_served(self):
+        page = render_html(_player_report())
+        assert "open this report over the network" not in page
+
+    def test_the_link_points_at_this_report_not_the_folder(self, tmp_path):
+        from modules.highlight_report import serve_url_for
+        url = serve_url_for("http://192.168.0.10:8000/", r"D:\m\a b&c_why.html")
+        # Landing on a directory listing means reading the filename off a phone
+        # screen, which is the thing this exists to avoid.
+        assert url == "http://192.168.0.10:8000/a%20b%26c_why.html"
+
+    def test_a_base_without_a_trailing_slash_still_works(self):
+        from modules.highlight_report import serve_url_for
+        assert serve_url_for("http://h:8000", "x_why.html") == \
+            "http://h:8000/x_why.html"
+
+    def test_an_empty_base_is_not_a_link(self):
+        from modules.highlight_report import serve_url_for
+        assert serve_url_for("", "x_why.html") is None
+        assert serve_url_for("   ", "x_why.html") is None
+        assert serve_url_for(None, "x_why.html") is None
+
+    def test_the_standalone_copy_carries_it_too(self):
+        """The copy with no players is the one that most needs the address."""
+        page = render_html(_player_report(), serve_url="http://h:8000/r.html")
+        assert "<video" not in page
+        assert "open this report over the network" in page
+        assert 'href="http://h:8000/r.html"' in page
+
+    def test_a_re_render_from_the_record_keeps_the_link(self):
+        """Both narration passes re-render from the record and know nothing
+        about serving, so the record has to carry it."""
+        rep = dict(_player_report())
+        rep["serve_url"] = "http://h:8000/r.html"
+        assert "open this report over the network" in render_html(rep)
+
+    def test_write_report_records_it_for_those_re_renders(self, tmp_path):
+        from modules.highlight_report import write_report
+        rep = dict(_player_report())
+        out = tmp_path / "r_why.html"
+        write_report(rep, str(out), link_media=False,
+                     serve_base="http://h:8000/")
+        assert rep["serve_url"] == "http://h:8000/r_why.html"
+        assert "open this report over the network" in out.read_text(encoding="utf-8")
+
+
+class TestMediaLink:
+    """The fallback that needs nothing running.
+
+    A browser cannot fetch `smb://`, but it can hand one to a player app, so a
+    report read off a share can still reach its footage. What it cannot do is
+    carry a position — which the page has to say, or the reader wonders why the
+    clip they were promised is not what started playing.
+    """
+
+    def test_no_link_without_a_base(self):
+        page = render_html(_player_report())
+        assert "open the source in a player app" not in page
+
+    def test_the_link_points_at_the_video_not_the_report(self):
+        from modules.highlight_report import media_url_for
+        rep = _player_report()
+        url = media_url_for("smb://192.168.0.10/movies/", rep)
+        assert url.startswith("smb://192.168.0.10/movies/")
+        assert url.endswith(".mp4"), "a share link to the HTML would open a viewer"
+
+    def test_the_base_may_or_may_not_end_in_a_slash(self):
+        from modules.highlight_report import media_url_for
+        rep = _player_report()
+        assert media_url_for("smb://h/m", rep) == media_url_for("smb://h/m/", rep)
+
+    def test_nothing_without_a_base_or_a_source(self):
+        from modules.highlight_report import media_url_for
+        assert media_url_for("", _player_report()) is None
+        assert media_url_for(None, _player_report()) is None
+        assert media_url_for("smb://h/m/", {"video": {}}) is None
+
+    def test_every_clip_carries_it_and_says_where_to_seek(self):
+        rep = _player_report()
+        page = render_html(rep, media_url="smb://h/m/v.mp4")
+        assert page.count("open the source in a player app") == 2
+        # The position cannot ride along in the URL, so it has to be in words.
+        assert "seek to" in page
+        assert "smb://h/m/v.mp4" in page
+
+    def test_it_survives_in_the_standalone_copy(self):
+        """The copy with no players is the one this exists for."""
+        page = render_html(_player_report(), media_src=None,
+                           media_url="smb://h/m/v.mp4")
+        assert "<video" not in page
+        assert "open the source in a player app" in page
+
+    def test_a_re_render_from_the_record_keeps_it(self):
+        rep = dict(_player_report())
+        rep["media_url"] = "smb://h/m/v.mp4"
+        assert "open the source in a player app" in render_html(rep)
+
+    def test_write_report_records_it(self, tmp_path):
+        from modules.highlight_report import write_report
+        rep = dict(_player_report())
+        out = tmp_path / "r_why.html"
+        write_report(rep, str(out), link_media=False,
+                     media_base="smb://h/movies/")
+        assert rep["media_url"].startswith("smb://h/movies/")
+        assert "open the source in a player app" in out.read_text(encoding="utf-8")

--- a/tests/test_story_run.py
+++ b/tests/test_story_run.py
@@ -1,0 +1,174 @@
+"""Tests for narrating a report as part of the run, and for which brief goes out.
+
+Two things are worth pinning here and neither is the prose:
+
+* the brief a captioner receives is not the brief an instruction-follower
+  receives. This is the bug that produced a page of recited rules instead of a
+  report, and it is invisible in every other test — the fake model returns its
+  canned reply whatever it is sent, so only the recorded ``system`` catches it;
+* narration at the tail of a pipeline never costs the run. The cut and the
+  report exist by the time it starts, so a model that cannot be reached, a pass
+  that raises, or a cancelled run must all come back as a number and a log line.
+
+No Qt here: this imports the pure half only, and the GUI's checkboxes are
+somebody else's test.
+"""
+from __future__ import annotations
+
+import pytest
+
+from modules import chapter_story, clip_story, story_run
+from modules.llm_models import is_captioner
+
+
+class _Recorder:
+    """Stands in for LLMModule, and keeps every system prompt it was sent."""
+
+    def __init__(self, reply="A bench, and two people on it."):
+        self.reply, self.systems = reply, []
+
+    def generate(self, prompt, system="", max_tokens=1024, images=None, **kw):
+        self.systems.append(system)
+        return self.reply
+
+    def accepts_images(self):
+        return True
+
+
+class TestWhichBrief:
+    @pytest.mark.parametrize("name", ["joycaption:q4", "ollama/JoyCaption",
+                                      "joy-caption-beta", "joy_caption"])
+    def test_captioners_are_recognised_through_tags_and_prefixes(self, name):
+        assert is_captioner(name)
+
+    @pytest.mark.parametrize("name", ["qwen2.5vl:7b", "llava-llama3:8b", "",
+                                      None])
+    def test_everything_else_is_an_instruction_follower(self, name):
+        assert not is_captioner(name)
+
+    def test_a_captioner_is_not_sent_a_numbered_rulebook(self):
+        # The whole point: "1." in the system prompt is what came back as the
+        # answer, so its absence is the thing to assert.
+        for module in (chapter_story, clip_story):
+            flat = module.system_prompt_for("joycaption:q4")
+            assert "Rules:" not in flat
+            assert "\n1. " not in flat
+
+    def test_an_instruction_follower_still_gets_the_rulebook(self):
+        assert chapter_story.system_prompt_for("qwen2.5vl:7b") == \
+            chapter_story.STORY_SYSTEM_PROMPT
+        assert clip_story.system_prompt_for("qwen2.5vl:7b") == \
+            clip_story.CLIP_SYSTEM_PROMPT
+
+    def test_an_unnamed_model_keeps_the_behaviour_this_code_always_had(self):
+        assert chapter_story.system_prompt_for(None) == \
+            chapter_story.STORY_SYSTEM_PROMPT
+
+    def test_the_flat_brief_keeps_what_the_rulebook_enforced(self):
+        # Flattening is a change of packaging, not of constraints. The two that
+        # would be missed silently: figures belong to the page, and a clip
+        # paragraph must attribute the run's claims rather than adopt them.
+        chapter = chapter_story.CAPTIONER_SYSTEM_PROMPT
+        assert "number" in chapter and "already" in chapter
+        clip = clip_story.CAPTIONER_SYSTEM_PROMPT
+        assert "number" in clip
+        assert "flagged" in clip
+
+    def test_the_brief_reaches_the_model(self, monkeypatch):
+        # Threading a prompt through four call sites is exactly the kind of
+        # change that compiles and does nothing, so follow it to the call.
+        llm = _Recorder()
+        report = {"segments": [{"start": 1.0, "end": 3.0, "range": "0:01-0:03"}]}
+        monkeypatch.setattr(clip_story, "_frames_delivered",
+                            lambda _llm, _images: 1)
+        clip_story.tell(report, llm=llm, frames_fn=lambda _s, _e: ["img"],
+                        model_name="joycaption:q4", log_fn=lambda _m: None)
+        assert llm.systems == [clip_story.CAPTIONER_SYSTEM_PROMPT]
+
+
+class TestWhatTheRunAsksFor:
+    def test_both_scales_are_narrated_by_default(self):
+        # The default is the feature: a report that answers "what is in this
+        # clip" but not "what was this stretch doing" can still be asked
+        # something it has no answer for.
+        assert story_run.wanted({}) == (True, True)
+
+    def test_either_pass_can_be_turned_off_for_a_run(self):
+        # The cost is a call per chapter plus one per clip, so switching one off
+        # has to actually switch it off — not merely fail to switch it on.
+        assert story_run.wanted({"narrate_chapters": False}) == (False, True)
+        assert story_run.wanted({"narrate_clips": False}) == (True, False)
+        assert story_run.wanted({"narrate_chapters": False,
+                                 "narrate_clips": False}) == (False, False)
+
+    def test_nothing_wanted_means_no_model_is_ever_built(self, monkeypatch):
+        def _boom(*_a, **_kw):                      # pragma: no cover - guard
+            raise AssertionError("loaded a model for a run that wanted none")
+
+        monkeypatch.setattr("modules.advisor.load_llm", _boom)
+        assert story_run.narrate_report_file(
+            "nowhere.json",
+            config={"narrate_clips": False, "narrate_chapters": False},
+            log_fn=lambda _m: None) == {"chapters": 0, "clips": 0}
+
+
+class TestNarrationNeverCostsTheRun:
+    def test_an_unreachable_model_is_a_log_line_and_a_zero(self, monkeypatch):
+        monkeypatch.setattr("modules.advisor.load_llm",
+                            lambda *_a, **_kw: None)
+        said = []
+        assert story_run.narrate_report_file(
+            "nowhere.json", config={}, log_fn=said.append) == \
+            {"chapters": 0, "clips": 0}
+        assert any("could not reach" in line.lower() for line in said)
+
+    def test_a_model_that_raises_on_load_is_caught(self, monkeypatch):
+        def _boom(*_a, **_kw):
+            raise RuntimeError("no CUDA device")
+
+        monkeypatch.setattr("modules.advisor.load_llm", _boom)
+        said = []
+        assert story_run.narrate_report_file(
+            "nowhere.json", config={}, log_fn=said.append)["clips"] == 0
+        assert any("no CUDA device" in line for line in said)
+
+    def test_a_pass_that_raises_loses_its_paragraphs_and_nothing_else(
+            self, monkeypatch):
+        def _boom(*_a, **_kw):
+            raise ValueError("the report moved")
+
+        monkeypatch.setattr("modules.advisor.load_llm",
+                            lambda *_a, **_kw: _Recorder())
+        monkeypatch.setattr("modules.clip_story.tell_report_file", _boom)
+        said = []
+        assert story_run.narrate_report_file(
+            "nowhere.json", config={"narrate_chapters": False},
+            log_fn=said.append) == {"chapters": 0, "clips": 0}
+        assert any("the report moved" in line for line in said)
+
+    def test_a_blind_model_skips_the_clip_pass_rather_than_writing_from_figures(
+            self, monkeypatch):
+        # A model handed no pictures writes a fluent paragraph out of the
+        # measurements and nothing on the page marks it as invented.
+        class _Blind(_Recorder):
+            def accepts_images(self):
+                return False
+
+        monkeypatch.setattr("modules.advisor.load_llm",
+                            lambda *_a, **_kw: _Blind())
+        monkeypatch.setattr(
+            "modules.clip_story.tell_report_file",
+            lambda *_a, **_kw: pytest.fail("read clips it could not see"))
+        said = []
+        assert story_run.narrate_report_file(
+            "nowhere.json", config={"narrate_chapters": False},
+            log_fn=said.append)["clips"] == 0
+        assert any("cannot see" in line for line in said)
+
+    def test_a_cancelled_run_narrates_nothing(self, monkeypatch):
+        monkeypatch.setattr(
+            "modules.advisor.load_llm",
+            lambda *_a, **_kw: pytest.fail("built a model after cancel"))
+        assert story_run.narrate_report_file(
+            "nowhere.json", config={}, log_fn=lambda _m: None,
+            cancel_fn=lambda: True) == {"chapters": 0, "clips": 0}

--- a/tools/serve_report.py
+++ b/tools/serve_report.py
@@ -1,0 +1,116 @@
+"""A static file server that supports HTTP Range, for reading a report on a phone.
+
+`python -m http.server` is not enough here. It has no Range support, so a
+browser asked to start a video at 79 minutes has no way to ask for the bytes at
+79 minutes -- it can only fetch from the beginning, which for this footage is a
+400 MB download before the first frame appears. That reads as "the player does
+not work" and is really "the server cannot be seeked".
+
+So this adds the one missing piece: honour `Range: bytes=...` with a 206 and
+`Accept-Ranges: bytes`, and let everything else fall through to the stock
+handler. Nothing else about it is special.
+
+    python serve_report.py "D:\\movies" 8000
+
+Then browse to http://<this-machine>:8000/ from the phone and tap the report.
+Serving is read-only, but it is the whole directory to anyone on the network --
+stop it when you are done.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+_RANGE = re.compile(r"bytes=(\d*)-(\d*)$")
+
+
+class RangeHandler(SimpleHTTPRequestHandler):
+    def send_head(self):
+        header = self.headers.get("Range")
+        if not header:
+            # No range asked for: the stock path already does the right thing,
+            # except that a client cannot know seeking is available unless the
+            # first response says so.
+            self._plain = True
+            return super().send_head()
+        self._plain = False
+
+        match = _RANGE.match(header.strip())
+        path = self.translate_path(self.path)
+        if not match or os.path.isdir(path):
+            return super().send_head()
+        try:
+            fh = open(path, "rb")
+        except OSError:
+            self.send_error(404, "File not found")
+            return None
+
+        size = os.fstat(fh.fileno()).st_size
+        first, last = match.group(1), match.group(2)
+        if first == "":                      # a suffix range: the last N bytes
+            length = int(last or 0)
+            start, end = max(0, size - length), size - 1
+        else:
+            start = int(first)
+            end = int(last) if last else size - 1
+        end = min(end, size - 1)
+        if start > end or start >= size:
+            fh.close()
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{size}")
+            self.end_headers()
+            return None
+
+        self.send_response(206)
+        self.send_header("Content-Type", self.guess_type(path))
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+        self.send_header("Content-Length", str(end - start + 1))
+        self.end_headers()
+        fh.seek(start)
+        self._remaining = end - start + 1
+        return fh
+
+    def copyfile(self, source, outputfile):
+        if getattr(self, "_plain", True):
+            return super().copyfile(source, outputfile)
+        remaining = self._remaining
+        while remaining > 0:
+            chunk = source.read(min(64 * 1024, remaining))
+            if not chunk:
+                break
+            try:
+                outputfile.write(chunk)
+            except (BrokenPipeError, ConnectionResetError):
+                # The phone seeked again, or closed the tab. Normal, not an error.
+                return
+            remaining -= len(chunk)
+
+    def end_headers(self):
+        if getattr(self, "_plain", True):
+            self.send_header("Accept-Ranges", "bytes")
+        super().end_headers()
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    directory = argv[0] if argv else os.getcwd()
+    port = int(argv[1]) if len(argv) > 1 else 8000
+    if not os.path.isdir(directory):
+        print(f"not a directory: {directory}")
+        return 2
+    handler = partial(RangeHandler, directory=directory)
+    server = ThreadingHTTPServer(("0.0.0.0", port), handler)
+    print(f"serving {directory} on port {port} — Ctrl-C to stop")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Explanation belongs in both editions — why a moment was chosen and what the run measured is the thing this tool does instead of handing you a result you cannot interrogate. The Pro side landed as "narrate the clips and chapters a run kept"; this is the same feature carried over by hand, since the two histories share no commits.

  clip_story.py   a paragraph per kept clip, read off the clip's frames
  story_run.py    runs both narration passes over a finished report, so
                  the answer exists without the user knowing to ask for
                  it after the run has already finished
  serve_report.py a static server that speaks HTTP Range, so a report
                  read on a phone can seek into the footage instead of
                  downloading 400 MB to reach minute 79

Unfinished and parked on a branch: the wiring in main.py, pipeline.py and config.yaml predates the #15 merge and still has to be rebased onto it. Committed so the free-side half of the port stops living only in a working tree.

<!-- Thanks for contributing to VideoHighlighter! -->

## What & why

<!-- What does this PR change, and why? -->

## Pipeline note (if applicable)

<!-- If this touches the final_segments pipeline, which side? pre-CompositionEngine / post-filter -->

## Checklist

- [x] I have read the [Contributing guide](../CONTRIBUTING.md).
- [x] **I agree to the [Contributor License Agreement](../CLA.md)** — I grant the project's copyright holders a license to use my contribution under AGPLv3 and any commercial/Pro license.
- [x] PR is focused on a single feature/fix.
